### PR TITLE
240 mlord calendar create

### DIFF
--- a/careconnect2025/backend/core/src/main/java/com/careconnect/controller/v2/TaskControllerV2.java
+++ b/careconnect2025/backend/core/src/main/java/com/careconnect/controller/v2/TaskControllerV2.java
@@ -1,0 +1,60 @@
+package com.careconnect.controller.v2;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.careconnect.dto.v2.TaskDtoV2;
+import com.careconnect.model.Task;
+import com.careconnect.service.v2.TaskServiceV2;
+
+@RestController
+@RequestMapping("/v2/api/tasks")
+public class TaskControllerV2 {
+
+    private final TaskServiceV2 taskService;
+
+    public TaskControllerV2(TaskServiceV2 taskService) {
+        this.taskService = taskService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Task>> getAllTasks() {
+        return ResponseEntity.ok(taskService.getAllTasks());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Task> getTaskById(@PathVariable Long id) {
+        Task task = taskService.getTaskById(id);
+        return task != null ? ResponseEntity.ok(task) : ResponseEntity.notFound().build();
+    }
+
+    @GetMapping("/patient/{patientId}")
+    public ResponseEntity<List<Task>> getTasksByPatient(@PathVariable Long patientId) {
+        return ResponseEntity.ok(taskService.getTasksByPatient(patientId));
+    }
+
+    @PostMapping("/patient/{patientId}")
+    public ResponseEntity<Task> createTask(@PathVariable Long patientId, @RequestBody TaskDtoV2 task) {
+        return ResponseEntity.ok(taskService.createTask(patientId, task));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Task> updateTask(@PathVariable Long id, @RequestBody TaskDtoV2 task) {
+        Task updated = taskService.updateTask(id, task);
+        return updated != null ? ResponseEntity.ok(updated) : ResponseEntity.notFound().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTask(@PathVariable Long id) {
+        return taskService.deleteTask(id) ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+}

--- a/careconnect2025/backend/core/src/main/java/com/careconnect/dto/v2/TaskDtoV2.java
+++ b/careconnect2025/backend/core/src/main/java/com/careconnect/dto/v2/TaskDtoV2.java
@@ -31,10 +31,10 @@ public class TaskDtoV2 {
     private String frequency;
 
     @Nullable
-    private int interval;
+    private Integer interval;
 
     @Nullable
-    private int count;
+    private Integer count;
 
     @Nullable
     private String daysOfWeek;

--- a/careconnect2025/backend/core/src/main/java/com/careconnect/dto/v2/TaskDtoV2.java
+++ b/careconnect2025/backend/core/src/main/java/com/careconnect/dto/v2/TaskDtoV2.java
@@ -1,0 +1,48 @@
+package com.careconnect.dto.v2;
+
+import io.micrometer.common.lang.Nullable;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TaskDtoV2 {
+    @NotNull(message = "Task name is required")
+    private String name;
+
+    @Nullable
+    private String description;
+
+    @NotNull(message = "Date is required")
+    private String date; // Stored as varchar(255) in DB
+
+    @Nullable
+    private String timeOfDay; // Stored as varchar(255) in DB
+
+    @NotNull(message = "Completion state is required")
+    private boolean isCompleted;
+
+    @Nullable
+    private String frequency;
+
+    @Nullable
+    private int interval;
+
+    @Nullable
+    private int count;
+
+    @Nullable
+    private String daysOfWeek;
+
+    @Nullable
+    private String taskType;
+
+    // Only used in UPDATE flow (optional for reassignments)
+    @Nullable
+    private Long patientId;
+}

--- a/careconnect2025/backend/core/src/main/java/com/careconnect/model/Task.java
+++ b/careconnect2025/backend/core/src/main/java/com/careconnect/model/Task.java
@@ -1,11 +1,19 @@
 package com.careconnect.model;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 import io.micrometer.common.lang.Nullable;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -22,26 +30,26 @@ public class Task {
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "patient_id")
     private Patient patient;
-    
+
     private String name;
     @Nullable
     private String description;
-    
+
     private String date;
     @Nullable
     private String timeOfDay;
-    
+
     private boolean isCompleted;
 
     private String taskType;
-    
+
     // FrequencyTask fields
     @Nullable
     private String frequency; // e.g. "daily", "weekly", etc.
     @Nullable
-    private int taskInterval; // Interval for the frequency, e.g. every 2 days
+    private Integer taskInterval; // Interval for the frequency, e.g. every 2 days
     @Nullable
-    private int doCount; // Number of occurrences
+    private Integer doCount; // Number of occurrences
 
     // DayOfWeekTask fields
     @Nullable

--- a/careconnect2025/backend/core/src/main/java/com/careconnect/service/v2/TaskServiceV2.java
+++ b/careconnect2025/backend/core/src/main/java/com/careconnect/service/v2/TaskServiceV2.java
@@ -1,0 +1,119 @@
+package com.careconnect.service.v2;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.careconnect.dto.v2.TaskDtoV2;
+import com.careconnect.exception.AppException;
+import com.careconnect.model.Patient;
+import com.careconnect.model.Task;
+import com.careconnect.repository.PatientRepository;
+import com.careconnect.repository.TaskRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+@Service
+@Transactional
+public class TaskServiceV2 {
+
+    private TaskRepository taskRepository;
+    private PatientRepository patientRepository;
+
+    public TaskServiceV2(TaskRepository taskRepository, PatientRepository patientRepository) {
+        this.taskRepository = taskRepository;
+        this.patientRepository = patientRepository;
+    }
+
+    public Task getTaskById(Long taskId) {
+        return taskRepository.findById(taskId)
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "Task not found"));
+    }
+
+    public List<Task> getTasksByPatient(Long patientId) {
+        Optional<List<Task>> tasksOpt = taskRepository.findByPatientId(patientId);
+        return tasksOpt.orElseGet(ArrayList::new);
+    }
+
+    public Task createTask(Long patientId, TaskDtoV2 task) {
+        // Get the patient and ensure it exists
+        Patient patient = patientRepository.findById(patientId).orElseThrow(
+                () -> new AppException(HttpStatus.NOT_FOUND, "Patient not found"));
+        System.out.println("Creating task for patient: " + patient.getId());
+        System.out.println("Task details: " + task);
+        Task newTask = Task.builder()
+                .name(task.getName())
+                .description(task.getDescription())
+                .date(task.getDate())
+                .timeOfDay(task.getTimeOfDay())
+                .isCompleted(task.isCompleted())
+                .frequency(task.getFrequency())
+                .taskInterval(task.getInterval())
+                .doCount(task.getCount())
+                .daysOfWeek(task.getDaysOfWeek())
+                .taskType(task.getTaskType())
+                .patient(patient)
+                .build();
+        System.out.println("New task created: " + newTask);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        try {
+            String jsonString = mapper.writeValueAsString(newTask);
+            System.out.println("Serialized task: " + jsonString);
+            return taskRepository.save(newTask);
+        } catch (Exception e) {
+            throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Failed to create task: " + e.getMessage());
+        }
+    }
+
+    public Task updateTask(Long taskId, TaskDtoV2 task) {
+        Task existingTask = getTaskById(taskId);
+
+        // Reassign patient only if provided
+        if (task.getPatientId() != null) {
+            Patient newPatient = patientRepository.findById(task.getPatientId())
+                    .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "Patient not found"));
+            existingTask.setPatient(newPatient);
+        }
+
+        // Update fields as necessary
+        existingTask.setName(task.getName());
+        existingTask.setDescription(task.getDescription());
+        existingTask.setDate(task.getDate());
+        existingTask.setTimeOfDay(task.getTimeOfDay());
+        existingTask.setCompleted(task.isCompleted());
+        existingTask.setTaskType(task.getTaskType());
+        existingTask.setFrequency(task.getFrequency());
+        existingTask.setTaskInterval(task.getInterval());
+        existingTask.setDoCount(task.getCount());
+        existingTask.setDaysOfWeek(task.getDaysOfWeek());
+
+        // Save the updated task
+        return taskRepository.save(existingTask);
+    }
+
+    public boolean deleteTask(Long taskId) {
+        Task task = getTaskById(taskId);
+        taskRepository.delete(task);
+        return true;
+    }
+
+    public boolean existsById(Long taskId) {
+        return taskRepository.findById(taskId).isPresent();
+    }
+
+    public List<Task> getAllTasks() {
+        List<Task> tasks = taskRepository.findAll();
+        if (tasks.isEmpty()) {
+            throw new AppException(HttpStatus.NOT_FOUND, "No tasks found");
+        }
+        return tasks;
+    }
+
+    // Additional methods for TaskService can be added here
+}

--- a/careconnect2025/backend/core/src/main/java/com/careconnect/service/v2/TaskServiceV2.java
+++ b/careconnect2025/backend/core/src/main/java/com/careconnect/service/v2/TaskServiceV2.java
@@ -52,8 +52,8 @@ public class TaskServiceV2 {
                 .timeOfDay(task.getTimeOfDay())
                 .isCompleted(task.isCompleted())
                 .frequency(task.getFrequency())
-                .taskInterval(task.getInterval())
-                .doCount(task.getCount())
+                .taskInterval(task.getInterval() != null ? task.getInterval() : 0)
+                .doCount(task.getCount() != null ? task.getCount() : 0)
                 .daysOfWeek(task.getDaysOfWeek())
                 .taskType(task.getTaskType())
                 .patient(patient)
@@ -92,6 +92,14 @@ public class TaskServiceV2 {
         existingTask.setTaskInterval(task.getInterval());
         existingTask.setDoCount(task.getCount());
         existingTask.setDaysOfWeek(task.getDaysOfWeek());
+
+        // Only overwrite recurrence fields if they’re provided
+        if (task.getInterval() != null) {
+            existingTask.setTaskInterval(task.getInterval());
+        }
+        if (task.getCount() != null) {
+            existingTask.setDoCount(task.getCount());
+        }
 
         // Save the updated task
         return taskRepository.save(existingTask);

--- a/careconnect2025/frontend/lib/config/router/app_router.dart
+++ b/careconnect2025/frontend/lib/config/router/app_router.dart
@@ -1,43 +1,44 @@
+import 'package:care_connect_app/features/calls/presentation/pages/jitsi_meeting_screen.dart';
 import 'package:care_connect_app/features/integrations/presentation/pages/home_monitoring_screen.dart';
 import 'package:care_connect_app/features/integrations/presentation/pages/medication_management.dart';
 import 'package:care_connect_app/features/integrations/presentation/pages/smart_devices.dart';
 import 'package:care_connect_app/features/integrations/presentation/pages/wearables_screen.dart';
-import 'package:care_connect_app/features/calls/presentation/pages/jitsi_meeting_screen.dart';
 import 'package:care_connect_app/features/profile/presentation/pages/profile_settings_page.dart';
 import 'package:care_connect_app/features/tasks/presentation/assign_task_screen.dart';
+import 'package:care_connect_app/features/tasks/presentation/calendar_assisiant.dart';
 import 'package:care_connect_app/features/tasks/presentation/custom_task_screen.dart';
 import 'package:care_connect_app/features/tasks/presentation/pre_defined_task_screen.dart';
 import 'package:care_connect_app/features/tasks/presentation/tasks_screen.dart';
-import 'package:care_connect_app/pages/profile_page.dart';
-import 'package:care_connect_app/pages/settings_page.dart';
 import 'package:care_connect_app/pages/ai_configuration_page.dart';
 import 'package:care_connect_app/pages/file_management_page.dart';
+import 'package:care_connect_app/pages/profile_page.dart';
+import 'package:care_connect_app/pages/settings_page.dart';
 import 'package:care_connect_app/widgets/hybrid_video_call_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 
-import '../../features/welcome/presentation/pages/welcome_page.dart';
+import '../../features/analytics/analytics_page.dart';
 import '../../features/auth/presentation/pages/login_page.dart';
 import '../../features/auth/presentation/pages/oauth_callback_page.dart';
-import '../../features/dashboard/presentation/pages/caregiver_dashboard.dart';
-import '../../features/dashboard/presentation/pages/patient_dashboard.dart';
-import '../../features/onboarding/presentation/pages/patient_registration.dart';
-import '../../features/auth/presentation/pages/sign_up_screen.dart';
-import '../../features/payments/presentation/pages/select_package_page.dart';
-import '../../features/payments/presentation/pages/subscription_management_page.dart';
-import '../../features/dashboard/presentation/pages/add_patient_screen.dart';
 import '../../features/auth/presentation/pages/password_reset_page.dart';
 import '../../features/auth/presentation/pages/reset_password_screen.dart'; // ADD THIS IMPORT
-import '../../features/payments/models/package_model.dart';
-import '../../features/social/presentation/pages/main_feed_screen.dart';
-import '../../features/gamification/presentation/pages/gamification_screen.dart';
-import '../../features/payments/presentation/pages/stripe_checkout_page.dart';
-import '../../features/analytics/analytics_page.dart';
-import '../../features/payments/presentation/pages/payment_success_page.dart';
-import '../../features/payments/presentation/pages/payment_cancel_page.dart';
+import '../../features/auth/presentation/pages/sign_up_screen.dart';
+import '../../features/dashboard/presentation/pages/add_patient_screen.dart';
+import '../../features/dashboard/presentation/pages/caregiver_dashboard.dart';
+import '../../features/dashboard/presentation/pages/patient_dashboard.dart';
 import '../../features/dashboard/presentation/pages/patient_status_page.dart';
+import '../../features/gamification/presentation/pages/gamification_screen.dart';
+import '../../features/onboarding/presentation/pages/patient_registration.dart';
+import '../../features/payments/models/package_model.dart';
+import '../../features/payments/presentation/pages/payment_cancel_page.dart';
+import '../../features/payments/presentation/pages/payment_success_page.dart';
+import '../../features/payments/presentation/pages/select_package_page.dart';
+import '../../features/payments/presentation/pages/stripe_checkout_page.dart';
+import '../../features/payments/presentation/pages/subscription_management_page.dart';
+import '../../features/social/presentation/pages/main_feed_screen.dart';
+import '../../features/welcome/presentation/pages/welcome_page.dart';
 import '../../providers/user_provider.dart';
-import 'package:provider/provider.dart';
 
 /// Helper function to navigate to the appropriate dashboard based on user role
 void navigateToDashboard(BuildContext context, {String? role}) {
@@ -109,7 +110,7 @@ final GoRouter appRouter = GoRouter(
           case 'ADMIN':
             return const CaregiverDashboard();
           default:
-          // Unknown role, redirect to login
+            // Unknown role, redirect to login
             WidgetsBinding.instance.addPostFrameCallback((_) {
               context.go('/login');
             });
@@ -485,6 +486,12 @@ final GoRouter appRouter = GoRouter(
       builder: (_, __) => const VideoCallTestPage(),
     ),
 
+    //Adding Calendar Assistant route
+    GoRoute(
+      path: '/calendar',
+      builder: (_, __) => const CalendarAssistantScreen(),
+    ),
+
     // Handle routes from legacy menus
     GoRoute(
       path: '/taskscheduling',
@@ -523,8 +530,9 @@ final GoRouter appRouter = GoRouter(
       builder: (context, state) {
         final patientIdStr = state.uri.queryParameters['patientId'];
         final patientId = int.tryParse(patientIdStr ?? '0') ?? 0;
-        final patientName = state.uri.queryParameters['patientName'] ?? 'Name Not Found';
-      // Return the Tasks widget with the patientId
+        final patientName =
+            state.uri.queryParameters['patientName'] ?? 'Name Not Found';
+        // Return the Tasks widget with the patientId
         return TasksScreen(patientId: patientId, patientName: patientName);
       },
     ),
@@ -533,7 +541,8 @@ final GoRouter appRouter = GoRouter(
       builder: (context, state) {
         final patientIdStr = state.uri.queryParameters['patientId'];
         final patientId = int.tryParse(patientIdStr ?? '0') ?? 0;
-        final patientName = state.uri.queryParameters['patientName'] ?? 'Name Not Found';
+        final patientName =
+            state.uri.queryParameters['patientName'] ?? 'Name Not Found';
         return AssignTaskScreen(patientId: patientId, patientName: patientName);
       },
     ),
@@ -542,7 +551,8 @@ final GoRouter appRouter = GoRouter(
       builder: (context, state) {
         final patientIdStr = state.uri.queryParameters['patientId'];
         final patientId = int.tryParse(patientIdStr ?? '0') ?? 0;
-        final patientName = state.uri.queryParameters['patientName'] ?? 'Name Not Found';
+        final patientName =
+            state.uri.queryParameters['patientName'] ?? 'Name Not Found';
         return CustomTaskScreen(patientId: patientId, patientName: patientName);
       },
     ),
@@ -553,8 +563,13 @@ final GoRouter appRouter = GoRouter(
         final patientId = int.tryParse(patientIdStr ?? '0') ?? 0;
         final templateIdStr = state.uri.queryParameters['templateId'];
         final templateId = int.tryParse(templateIdStr ?? '0') ?? 0;
-        final patientName = state.uri.queryParameters['patientName'] ?? 'Name Not Found';
-        return PreDefinedTaskScreen(patientId: patientId, templateId: templateId, patientName: patientName);
+        final patientName =
+            state.uri.queryParameters['patientName'] ?? 'Name Not Found';
+        return PreDefinedTaskScreen(
+          patientId: patientId,
+          templateId: templateId,
+          patientName: patientName,
+        );
       },
     ),
   ],

--- a/careconnect2025/frontend/lib/features/tasks/models/task_model.dart
+++ b/careconnect2025/frontend/lib/features/tasks/models/task_model.dart
@@ -44,8 +44,6 @@ class Task {
               : List<bool>.from(json['daysOfWeek']))
         : null;
 
-    print("📅 Parsed daysOfWeek for ${json['name']}: $parsedDays");
-
     return Task(
       id: json['id'] != null ? json['id'] as int : -1,
       name: json['name'],
@@ -72,13 +70,6 @@ class Task {
   }
 
   Map<String, dynamic> toJson() {
-    String resolvedTaskType = taskType ?? "custom"; // Default task type
-    if (daysOfWeek != null && daysOfWeek!.contains(true)) {
-      resolvedTaskType = "dayOfWeek";
-    } else if (frequency != null && interval != null) {
-      resolvedTaskType = "frequency";
-    }
-
     return {
       'name': name,
       'description': description,
@@ -92,7 +83,7 @@ class Task {
       'interval': interval,
       'count': count,
       'daysOfWeek': daysOfWeek != null ? jsonEncode(daysOfWeek) : null,
-      'taskType': resolvedTaskType,
+      'taskType': taskType ?? "general",
       'patientId': userId,
     };
   }
@@ -102,9 +93,6 @@ class Task {
   }
 
   List<Task> expandOccurrences() {
-    print(
-      "🔍 expandOccurrences -> freq=$frequency interval=$interval count=$count",
-    );
     // If not recurring, return the single task
     if (frequency == null) {
       return [this];

--- a/careconnect2025/frontend/lib/features/tasks/models/task_model.dart
+++ b/careconnect2025/frontend/lib/features/tasks/models/task_model.dart
@@ -16,9 +16,11 @@ class Task {
   String? frequency; // e.g., 'daily', 'weekly', 'monthly'
   int? interval; // e.g., every 2 days, every 3 weeks
   int? count; // Number of occurrences
-  List<bool>? daysOfWeek; // e.g., [false, true, false, true, false, true, false] for Sun, Mon, Tue, Wed, Thu, Fri, Sat
+  List<bool>?
+  daysOfWeek; // e.g., [false, true, false, true, false, true, false] for Sun, Mon, Tue, Wed, Thu, Fri, Sat
 
-
+  //NEW FIELD for V2
+  final String? taskType;
 
   Task({
     required this.id,
@@ -33,8 +35,9 @@ class Task {
     this.interval,
     this.count,
     this.daysOfWeek,
+    this.taskType,
   });
-  
+
   factory Task.fromJson(Map<String, dynamic> json) {
     return Task(
       id: json['id'] != null ? json['id'] as int : -1,
@@ -51,16 +54,17 @@ class Task {
                   : json['timeOfDay']['minute'],
             )
           : null,
-      userId: json['assignedTo'],
+      userId: json['patient']?['id'],
       isComplete: json['isComplete'] ?? false,
       frequency: json['frequency'],
       interval: json['taskInterval'],
       count: json['doCount'],
       daysOfWeek: json['daysOfWeek'] != null
           ? (json['daysOfWeek'] is String
-              ? List<bool>.from(jsonDecode(json['daysOfWeek']))
-              : List<bool>.from(json['daysOfWeek']))
-          : null
+                ? List<bool>.from(jsonDecode(json['daysOfWeek']))
+                : List<bool>.from(json['daysOfWeek']))
+          : null,
+      taskType: json['taskType'],
     );
   }
 
@@ -85,6 +89,7 @@ class Task {
       'doCount': count,
       'daysOfWeek': jsonEncode(daysOfWeek),
       'taskType': taskType,
+      'patientId': userId,
     };
   }
 

--- a/careconnect2025/frontend/lib/features/tasks/models/task_model.dart
+++ b/careconnect2025/frontend/lib/features/tasks/models/task_model.dart
@@ -13,14 +13,13 @@ class Task {
   TimeOfDay? timeOfDay; // Optional, can be null if not set
   bool isComplete;
   List<Notification_dto>? notifications;
-  String? frequency; // e.g., 'daily', 'weekly', 'monthly'
-  int? interval; // e.g., every 2 days, every 3 weeks
-  int? count; // Number of occurrences
-  List<bool>?
-  daysOfWeek; // e.g., [false, true, false, true, false, true, false] for Sun, Mon, Tue, Wed, Thu, Fri, Sat
 
-  //NEW FIELD for V2
-  final String? taskType;
+  //Recurrence fields
+  String? frequency; // e.g., daily, weekly, monthly, yearly
+  int? interval; // number of days/weeks/months between recurrences
+  int? count; // number of total occurrences
+  List<bool>? daysOfWeek; // e.g., [false, true, false, true, ...] for Mon/Wed
+  final String? taskType; // "General" | "Lab" | "Appointment" | "custom"
 
   Task({
     required this.id,
@@ -39,10 +38,18 @@ class Task {
   });
 
   factory Task.fromJson(Map<String, dynamic> json) {
+    final parsedDays = json['daysOfWeek'] != null
+        ? (json['daysOfWeek'] is String
+              ? List<bool>.from(jsonDecode(json['daysOfWeek']))
+              : List<bool>.from(json['daysOfWeek']))
+        : null;
+
+    print("📅 Parsed daysOfWeek for ${json['name']}: $parsedDays");
+
     return Task(
       id: json['id'] != null ? json['id'] as int : -1,
       name: json['name'],
-      description: json['description'],
+      description: json['description'] ?? "",
       date: DateTime.parse(json['date']),
       timeOfDay: json['timeOfDay'] != null
           ? TimeOfDay(
@@ -57,38 +64,35 @@ class Task {
       userId: json['patient']?['id'],
       isComplete: json['isComplete'] ?? false,
       frequency: json['frequency'],
-      interval: json['taskInterval'],
-      count: json['doCount'],
-      daysOfWeek: json['daysOfWeek'] != null
-          ? (json['daysOfWeek'] is String
-                ? List<bool>.from(jsonDecode(json['daysOfWeek']))
-                : List<bool>.from(json['daysOfWeek']))
-          : null,
+      interval: json['interval'] ?? json['taskInterval'],
+      count: json['count'] ?? json['doCount'],
+      daysOfWeek: parsedDays,
       taskType: json['taskType'],
     );
   }
 
   Map<String, dynamic> toJson() {
-    String taskType = 'custom'; // Default task type
-    if (daysOfWeek != null) {
-      taskType = 'dayOfWeek';
+    String resolvedTaskType = taskType ?? "custom"; // Default task type
+    if (daysOfWeek != null && daysOfWeek!.contains(true)) {
+      resolvedTaskType = "dayOfWeek";
     } else if (frequency != null && interval != null) {
-      taskType = 'frequency';
+      resolvedTaskType = "frequency";
     }
+
     return {
       'name': name,
       'description': description,
-      'date': date.toString(),
+      'date': date.toIso8601String(),
       'timeOfDay': timeOfDay != null
           ? "${timeOfDay!.hour}:${timeOfDay!.minute}"
           : null,
       'isCompleted': isComplete,
       'notifications': null,
       'frequency': frequency,
-      'taskInterval': interval,
-      'doCount': count,
-      'daysOfWeek': jsonEncode(daysOfWeek),
-      'taskType': taskType,
+      'interval': interval,
+      'count': count,
+      'daysOfWeek': daysOfWeek != null ? jsonEncode(daysOfWeek) : null,
+      'taskType': resolvedTaskType,
       'patientId': userId,
     };
   }
@@ -96,88 +100,110 @@ class Task {
   bool isValid() {
     return name.isNotEmpty && description.isNotEmpty;
   }
-}
 
-class FrequencyTask extends Task {
-  @override
-  final String frequency; // e.g., 'daily', 'weekly', 'monthly'
-  @override
-  final int interval; // e.g., every 2 days, every 3 weeks
-  @override
-  final int? count; // Number of occurrences
-
-  FrequencyTask({
-    required this.frequency,
-    required this.interval,
-    this.count = 0,
-    required super.id,
-    required super.name,
-    required super.description,
-    required super.date,
-    super.timeOfDay,
-    super.userId,
-    super.isComplete = false,
-    super.notifications,
-  });
-
-  factory FrequencyTask.fromJson(Map<String, dynamic> json) {
-    return FrequencyTask(
-      frequency: json['frequency'],
-      interval: json['taskInterval'],
-      count: json['doCount'],
-      id: json['id'],
-      name: json['name'],
-      description: json['description'],
-      date: DateTime.parse(json['date']),
-      timeOfDay: json['timeOfDay'] != null
-          ? TimeOfDay(
-              hour: json['timeOfDay']['hour'],
-              minute: json['timeOfDay']['minute'],
-            )
-          : null,
-      userId: json['userId'],
-      isComplete: json['isComplete'] ?? false,
-      notifications: (json['notifications'] as List?)
-          ?.map((n) => Notification_dto.fromJson(n))
-          .toList(),
+  List<Task> expandOccurrences() {
+    print(
+      "🔍 expandOccurrences -> freq=$frequency interval=$interval count=$count",
     );
-  }
-}
+    // If not recurring, return the single task
+    if (frequency == null) {
+      return [this];
+    }
 
-class DayOfWeekTask extends Task {
-  @override
-  final List<bool> daysOfWeek; // e.g., [true, false, true, false, true, false, false] for Mon, Wed, Fri
+    int safeInterval;
+    switch (frequency!.toLowerCase()) {
+      case "daily":
+        safeInterval = (interval ?? 1).clamp(1, 365);
+        break;
+      case "weekly":
+        safeInterval = (interval ?? 1).clamp(1, 52);
+        break;
+      case "monthly":
+        safeInterval = (interval ?? 1).clamp(1, 12);
+        break;
+      case "yearly":
+        safeInterval = (interval ?? 1).clamp(1, 100);
+        break;
+      default:
+        safeInterval = 1;
+    }
 
-  DayOfWeekTask({
-    required this.daysOfWeek,
-    required super.id,
-    required super.name,
-    required super.description,
-    required super.date,
-    super.timeOfDay,
-    super.userId,
-    super.isComplete = false,
-    super.notifications,
-  });
+    int effectiveCount = (count == null || count! <= 0) ? 0 : count!;
 
-  factory DayOfWeekTask.fromJson(Map<String, dynamic> json) {
-    return DayOfWeekTask(
-      daysOfWeek: List<bool>.from(json['daysOfWeek']),
-      id: json['id'],
-      name: json['name'],
-      description: json['description'],
-      date: DateTime.parse(json['date']),
-      timeOfDay: json['timeOfDay'] != null
-          ? TimeOfDay(
-              hour: json['timeOfDay']['hour'],
-              minute: json['timeOfDay']['minute'],
-            )
-          : null,
-      userId: json['userId'],
-      isComplete: json['isComplete'] ?? false,
-      notifications: (json['notifications'] as List?)
-          ?.map((n) => Notification_dto.fromJson(n))
-          .toList(),
-    );
+    // Fallbacks if count not set
+    if (effectiveCount <= 0) {
+      switch (frequency!.toLowerCase()) {
+        case "daily":
+          effectiveCount = 30;
+          break;
+        case "weekly":
+          if (daysOfWeek != null && daysOfWeek!.contains(true)) {
+            effectiveCount = 12 * daysOfWeek!.where((d) => d).length;
+          } else {
+            effectiveCount = 12;
+          }
+          break;
+        case "monthly":
+          effectiveCount = 12;
+          break;
+        case "yearly":
+          effectiveCount = 5;
+          break;
+        default:
+          effectiveCount = 1;
+      }
+    }
+
+    final List<Task> occurrences = [];
+    DateTime current = DateTime(date.year, date.month, date.day);
+
+    for (int i = 0; i < effectiveCount; i++) {
+      occurrences.add(
+        Task(
+          id: id,
+          name: name,
+          description: description,
+          date: current,
+          timeOfDay: timeOfDay,
+          userId: userId,
+          isComplete: isComplete,
+          notifications: notifications,
+          frequency: frequency,
+          interval: safeInterval,
+          count: effectiveCount,
+          daysOfWeek: daysOfWeek,
+          taskType: taskType,
+        ),
+      );
+
+      switch (frequency!.toLowerCase()) {
+        case "daily":
+          current = current.add(Duration(days: safeInterval));
+          break;
+
+        case "weekly":
+          if (daysOfWeek != null && daysOfWeek!.contains(true)) {
+            DateTime next = current.add(const Duration(days: 1));
+            while (!daysOfWeek![next.weekday % 7]) {
+              next = next.add(const Duration(days: 1));
+            }
+            current = next;
+          } else {
+            current = current.add(Duration(days: safeInterval));
+          }
+          break;
+
+        case "monthly":
+          final startDay = date.day; // always use original start day
+          current = DateTime(current.year, current.month + 1, startDay);
+          break;
+
+        case "yearly":
+          current = DateTime(current.year + 1, current.month, current.day);
+          break;
+      }
+    }
+
+    return occurrences;
   }
 }

--- a/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
@@ -280,12 +280,40 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
   String? error;
   late DateTime _focusedDay;
   DateTime? _selectedDay;
+  bool _filtersExpanded = false;
+  Set<String> _selectedTypes = {};
+  Set<int> _selectedPatients = {};
+  Map<int, String> patientNames = {};
+
+  Map<DateTime, List<Task>> _filteredTasks = {};
 
   Map<DateTime, List<Task>> tasks = LinkedHashMap(
     equals: isSameDay,
     hashCode: (date) => date.day * 1000000 + date.month * 10000 + date.year,
   );
-  Map<int, String> patientNames = {};
+  void _applyFilters() {
+    setState(() {
+      _filteredTasks = {};
+      tasks.forEach((day, dayTasks) {
+        final keepers = dayTasks.where((task) {
+          if (_selectedTypes.isNotEmpty &&
+              !_selectedTypes.contains(task.taskType ?? "general")) {
+            return false;
+          }
+          if (_selectedPatients.isNotEmpty &&
+              (task.userId == null ||
+                  !_selectedPatients.contains(task.userId))) {
+            return false;
+          }
+          return true;
+        }).toList();
+
+        if (keepers.isNotEmpty) {
+          _filteredTasks[day] = keepers;
+        }
+      });
+    });
+  }
 
   /// Build a small colored dot + label for the legend
   Widget _buildLegendDot(Color color, String label) {
@@ -394,6 +422,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
 
       setState(() {
         tasks = TaskUtils.groupTasksByDate(allTasks);
+        _filteredTasks = Map.from(tasks); // initialize filters with everything
         isLoading = false;
       });
     } catch (e) {
@@ -451,6 +480,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         body: const Center(child: CircularProgressIndicator()),
       );
     }
+
     return Scaffold(
       drawer: const CommonDrawer(currentRoute: '/calendar'),
       appBar: AppBarHelper.createAppBar(
@@ -471,6 +501,172 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         child: SingleChildScrollView(
           child: Column(
             children: [
+              // Filters + Today button
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Collapsible Filter Panel
+                    Flexible(
+                      fit: FlexFit.tight,
+                      child: AnimatedContainer(
+                        duration: const Duration(milliseconds: 300),
+                        margin: const EdgeInsets.only(right: 12),
+                        child: Card(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Padding(
+                                    padding: const EdgeInsets.all(8.0),
+                                    child: Text(
+                                      "Filters",
+                                      style: TextStyle(
+                                        fontWeight: FontWeight.bold,
+                                        color: Theme.of(
+                                          context,
+                                        ).textTheme.bodyLarge?.color,
+                                      ),
+                                    ),
+                                  ),
+                                  IconButton(
+                                    icon: Icon(
+                                      _filtersExpanded
+                                          ? Icons.expand_more
+                                          : Icons.chevron_right,
+                                    ),
+                                    onPressed: () {
+                                      setState(() {
+                                        _filtersExpanded = !_filtersExpanded;
+                                      });
+                                    },
+                                  ),
+                                ],
+                              ),
+
+                              if (_filtersExpanded) ...[
+                                const Divider(),
+                                // Filter by Type
+                                Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 8.0,
+                                  ),
+                                  child: Wrap(
+                                    spacing: 8,
+                                    runSpacing: 4,
+                                    children: TaskTypeUtils.getSortedTypes()
+                                        .map((type) {
+                                          return FilterChip(
+                                            label: Text(
+                                              type[0].toUpperCase() +
+                                                  type.substring(1),
+                                            ),
+                                            selected: _selectedTypes.contains(
+                                              type,
+                                            ),
+                                            onSelected: (selected) {
+                                              setState(() {
+                                                if (selected) {
+                                                  _selectedTypes.add(type);
+                                                } else {
+                                                  _selectedTypes.remove(type);
+                                                }
+                                              });
+                                              _applyFilters();
+                                            },
+                                          );
+                                        })
+                                        .toList(),
+                                  ),
+                                ),
+                                const SizedBox(height: 12),
+                                // Filter by Patient (only if caregiver)
+                                if (Provider.of<UserProvider>(
+                                      context,
+                                      listen: false,
+                                    ).user?.isCaregiver ??
+                                    false)
+                                  Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 8.0,
+                                    ),
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        const Text("Patients"),
+                                        const SizedBox(height: 8),
+                                        Wrap(
+                                          spacing: 8,
+                                          runSpacing: 4,
+                                          children: patientNames.entries.map((
+                                            entry,
+                                          ) {
+                                            return FilterChip(
+                                              label: Text(entry.value),
+                                              selected: _selectedPatients
+                                                  .contains(entry.key),
+                                              onSelected: (selected) {
+                                                setState(() {
+                                                  if (selected) {
+                                                    _selectedPatients.add(
+                                                      entry.key,
+                                                    );
+                                                  } else {
+                                                    _selectedPatients.remove(
+                                                      entry.key,
+                                                    );
+                                                  }
+                                                });
+                                                _applyFilters();
+                                              },
+                                            );
+                                          }).toList(),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                const SizedBox(height: 12),
+                                Align(
+                                  alignment: Alignment.centerRight,
+                                  child: TextButton.icon(
+                                    icon: const Icon(Icons.clear),
+                                    label: const Text("Clear Filters"),
+                                    onPressed: () {
+                                      setState(() {
+                                        _selectedTypes.clear();
+                                        _selectedPatients.clear();
+                                      });
+                                      _applyFilters();
+                                    },
+                                  ),
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+
+                    // Today Button
+                    ElevatedButton.icon(
+                      icon: const Icon(Icons.today),
+                      label: const Text("Today"),
+                      onPressed: () {
+                        setState(() {
+                          _focusedDay = DateTime.now();
+                          _selectedDay = DateTime.now();
+                        });
+                      },
+                    ),
+                  ],
+                ),
+              ),
+
               // Calendar
               TableCalendar<Task>(
                 firstDay: DateTime.utc(2020, 1, 1),
@@ -478,7 +674,8 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
                 focusedDay: _focusedDay,
                 selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
                 eventLoader: (day) =>
-                    tasks[DateTime(day.year, day.month, day.day)] ?? [],
+                    _filteredTasks[DateTime(day.year, day.month, day.day)] ??
+                    [],
                 onDaySelected: (selectedDay, focusedDay) {
                   setState(() {
                     _selectedDay = selectedDay;
@@ -491,20 +688,24 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
                 calendarStyle: const CalendarStyle(markersMaxCount: 0),
                 calendarBuilders: CalendarBuilders(
                   defaultBuilder: (context, day, focusedDay) {
-                    final dayTasks = tasks[day] ?? [];
+                    final normalized = TaskUtils.normalizeDate(day);
+                    final dayTasks = _filteredTasks[normalized] ?? [];
                     return _buildDayCell(day, dayTasks, Colors.grey);
                   },
                   todayBuilder: (context, day, focusedDay) {
-                    final dayTasks = tasks[day] ?? [];
+                    final normalized = TaskUtils.normalizeDate(day);
+                    final dayTasks = _filteredTasks[normalized] ?? [];
                     return _buildDayCell(day, dayTasks, Colors.blue);
                   },
                   selectedBuilder: (context, day, focusedDay) {
-                    final dayTasks = tasks[day] ?? [];
+                    final normalized = TaskUtils.normalizeDate(day);
+                    final dayTasks = _filteredTasks[normalized] ?? [];
                     return _buildDayCell(day, dayTasks, Colors.green);
                   },
                 ),
               ),
               const SizedBox(height: 16),
+
               // Legend
               Padding(
                 padding: const EdgeInsets.all(8.0),
@@ -521,13 +722,22 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
                 ),
               ),
               const SizedBox(height: 16),
+
               // Task list for selected day
-              if (_selectedDay != null && tasks[_selectedDay] != null)
+              if (_selectedDay != null) ...[
                 Builder(
                   builder: (_) {
-                    final dayTasks = [...tasks[_selectedDay]!];
+                    final normalized = TaskUtils.normalizeDate(_selectedDay!);
+                    final dayTasks = [...?_filteredTasks[normalized] ?? []];
 
-                    //Sort chronologically by timeOfDay
+                    if (dayTasks.isEmpty) {
+                      return const Padding(
+                        padding: EdgeInsets.all(16.0),
+                        child: Text("No tasks for this day"),
+                      );
+                    }
+
+                    // Sort chronologically by timeOfDay
                     dayTasks.sort((a, b) {
                       if (a.timeOfDay != null && b.timeOfDay != null) {
                         final aMinutes =
@@ -597,12 +807,13 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
                       }).toList(),
                     );
                   },
-                )
-              else
+                ),
+              ] else ...[
                 const Padding(
                   padding: EdgeInsets.all(16.0),
                   child: Text("Select a day to view tasks"),
                 ),
+              ],
             ],
           ),
         ),

--- a/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
@@ -1,0 +1,756 @@
+// Class: CalendarAssistantScreen
+// Descritpion: Running the Calendar Assistant through notification and task systems of CareConnect
+
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:developer';
+
+import 'package:care_connect_app/features/tasks/models/task_model.dart';
+import 'package:care_connect_app/providers/user_provider.dart';
+import 'package:care_connect_app/services/api_service.dart';
+import 'package:care_connect_app/widgets/app_bar_helper.dart';
+import 'package:care_connect_app/widgets/common_drawer.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:table_calendar/table_calendar.dart';
+
+class CalendarAssistantScreen extends StatefulWidget {
+  const CalendarAssistantScreen({super.key});
+
+  @override
+  State<CalendarAssistantScreen> createState() =>
+      _CalendarAssistantScreenState();
+}
+
+class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
+  //State variables for loading status and if errors have occured.
+  bool isLoading = true;
+  String? error;
+
+  //Variables used throughout the  class for day selections of the user.
+  late DateTime _focusedDay;
+  DateTime? _selectedDay;
+
+  /// Store tasks grouped by day (with isSameDay logic)
+  Map<DateTime, List<Task>> tasks = LinkedHashMap(
+    equals: isSameDay,
+    hashCode: (date) => date.day * 1000000 + date.month * 10000 + date.year,
+  );
+
+  // Map patientId -> patient name
+  //This will be more required once the endpoint provides needed information.
+  Map<int, String> patientNames = {};
+
+  // Define task types and their colors, also requires endpoint for more use.
+  final Map<String, Color> taskTypeColors = {
+    'medication': Colors.red,
+    'appointment': Colors.blue,
+    'exercise': Colors.green,
+    'general': Colors.deepOrange,
+    'lab': Colors.purple,
+    'pharmacy': Colors.teal,
+    'medical': Colors.cyan,
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    _focusedDay = DateTime.now();
+    _loadTasksFromDb();
+  }
+
+  //Function for making sure the Calendar displayed has updated DB information
+  Future<void> _loadTasksFromDb() async {
+    setState(() {
+      isLoading = true;
+      error = null;
+    });
+
+    try {
+      final user = Provider.of<UserProvider>(context, listen: false).user;
+      if (user == null) {
+        setState(() {
+          error = "User not logged in.";
+          isLoading = false;
+        });
+        return;
+      }
+      List<Task> allTasks = [];
+      //Branching point if patient then you see your own event,
+      //if caregiver then you see your patients events
+      // --- PATIENT FLOW ---
+      if (user.isPatient) {
+        final response = await ApiService.getPatientTasks(
+          user.id,
+        ).timeout(const Duration(seconds: 30));
+        if (response.statusCode == 200) {
+          final List data = json.decode(response.body);
+          for (var raw in data) {
+            final map = Map<String, dynamic>.from(raw);
+
+            if (map['date'] != null && map['date'] is String) {
+              String d = map['date'];
+              if (!d.contains("T")) {
+                map['date'] = d.replaceFirst(" ", "T");
+              }
+            }
+
+            if (map['daysOfWeek'] == null || map['daysOfWeek'] == "null") {
+              map['daysOfWeek'] = [];
+            }
+
+            try {
+              final task = Task.fromJson(map);
+              allTasks.add(task);
+            } catch (e) {
+              log("Error: $e");
+            }
+          }
+        }
+      }
+      // --- CAREGIVER FLOW ---
+      else if (user.isCaregiver) {
+        final patientsResponse = await ApiService.getCaregiverPatients(user.id);
+        if (patientsResponse.statusCode == 200) {
+          final List patients = json.decode(patientsResponse.body);
+          //Need name information for assignements. This is to be refactored when endpoint is updated.
+          for (var patient in patients) {
+            final patientId = patient['patient']?['id'];
+            final firstName = patient['patient']?['firstName'] ?? '';
+            final lastName = patient['patient']?['lastName'] ?? '';
+
+            if (patientId != null) {
+              // Save the patient name for later lookup
+              patientNames[patientId] = "$firstName $lastName";
+            }
+
+            //Skipping patient with null id
+            if (patientId == null) {
+              continue;
+            }
+
+            final taskResponse = await ApiService.getPatientTasks(
+              patientId,
+            ).timeout(const Duration(seconds: 30));
+            if (taskResponse.statusCode == 200) {
+              final List data = json.decode(taskResponse.body);
+              for (var raw in data) {
+                final map = Map<String, dynamic>.from(raw);
+
+                if (map['date'] != null && map['date'] is String) {
+                  String d = map['date'];
+                  if (!d.contains("T")) {
+                    map['date'] = d.replaceFirst(" ", "T");
+                  }
+                }
+                if (map['daysOfWeek'] == null || map['daysOfWeek'] == "null") {
+                  map['daysOfWeek'] = [];
+                }
+
+                try {
+                  final task = Task.fromJson(map);
+                  allTasks.add(task);
+                } catch (e) {
+                  log("Error: $e");
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // --- GROUP TASKS BY DATE ---
+      final grouped = LinkedHashMap<DateTime, List<Task>>(
+        equals: isSameDay,
+        hashCode: (date) => date.day * 1000000 + date.month * 10000 + date.year,
+      );
+
+      for (var task in allTasks) {
+        final dateKey = DateTime(
+          task.date.year,
+          task.date.month,
+          task.date.day,
+        );
+        grouped.putIfAbsent(dateKey, () => []);
+        grouped[dateKey]!.add(task);
+      }
+      setState(() {
+        tasks = grouped;
+        isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        error = "Error: $e";
+        isLoading = false;
+      });
+    }
+  }
+
+  //Things in UI functions succh as dart may need to be updated to match new UI requirements.
+  @override
+  Widget build(BuildContext context) {
+    if (isLoading) {
+      return Scaffold(
+        drawer: const CommonDrawer(currentRoute: '/calendar'),
+        appBar: AppBarHelper.createAppBar(
+          context,
+          title: 'Calendar Assistant',
+          centerTitle: true,
+        ),
+        body: const Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(height: 16),
+              Text('Loading Calendar ...'),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Scaffold(
+      drawer: const CommonDrawer(currentRoute: '/calendar'),
+      appBar: AppBarHelper.createAppBar(
+        context,
+        title: 'Calendar Assistant',
+        centerTitle: true,
+        additionalActions: [
+          TextButton.icon(
+            icon: const Icon(Icons.add, color: Colors.white),
+            label: const Text(
+              "Add Task",
+              style: TextStyle(color: Colors.white),
+            ),
+            onPressed: _addTask,
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              TableCalendar<Task>(
+                firstDay: DateTime.utc(2020, 1, 1),
+                lastDay: DateTime.utc(2030, 12, 31),
+                focusedDay: _focusedDay,
+                selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
+                eventLoader: (day) => tasks[day] ?? [],
+                onDaySelected: (selectedDay, focusedDay) {
+                  setState(() {
+                    _selectedDay = selectedDay;
+                    _focusedDay = focusedDay;
+                  });
+                },
+                rowHeight: 100,
+                calendarFormat: CalendarFormat.month,
+                availableCalendarFormats: const {CalendarFormat.month: 'Month'},
+                calendarStyle: const CalendarStyle(markersMaxCount: 0),
+                headerVisible: true,
+                calendarBuilders: CalendarBuilders(
+                  defaultBuilder: (context, day, focusedDay) {
+                    final dayTasks = tasks[day] ?? [];
+                    return _buildDayCell(day, dayTasks, Colors.grey);
+                  },
+                  todayBuilder: (context, day, focusedDay) {
+                    final dayTasks = tasks[day] ?? [];
+                    return _buildDayCell(day, dayTasks, Colors.blue);
+                  },
+                  selectedBuilder: (context, day, focusedDay) {
+                    final dayTasks = tasks[day] ?? [];
+                    return _buildDayCell(day, dayTasks, Colors.green);
+                  },
+                ),
+              ),
+
+              const SizedBox(height: 16),
+              // Task list with edit/remove buttons
+              if (_selectedDay != null && tasks[_selectedDay] != null)
+                ...tasks[_selectedDay]!.map((task) {
+                  /* final assignedName = task.userId != null
+                      ? patientNames[task.userId] ?? "Unknown Patient"
+                      : "Unassigned";*/
+
+                  return ListTile(
+                    leading: const Icon(Icons.task),
+                    title: Text(
+                      //"$assignedName: ${task.name}", Will encoperate once endpoint is updated
+                      task.name,
+                      style: const TextStyle(fontWeight: FontWeight.w500),
+                    ),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.edit, color: Colors.blue),
+                          tooltip: 'Edit Task',
+                          onPressed: () => _editTask(task),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.delete, color: Colors.red),
+                          tooltip: 'Remove Task',
+                          onPressed: () => _removeTask(task),
+                        ),
+                      ],
+                    ),
+                  );
+                })
+              else
+                const Padding(
+                  padding: EdgeInsets.all(16.0),
+                  child: Text("Select a day to view tasks"),
+                ),
+
+              const SizedBox(height: 16),
+
+              // Legend: needs refactoring based on update to taskType
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Wrap(
+                  spacing: 16,
+                  children: taskTypeColors.entries
+                      .map((e) => _buildLegendDot(e.value, e.key))
+                      .toList(),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  //Function builds color legend based on available colors defined
+  Widget _buildLegendDot(Color color, String label) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 10,
+          height: 10,
+          decoration: BoxDecoration(shape: BoxShape.circle, color: color),
+        ),
+        const SizedBox(width: 4),
+        Text(label),
+      ],
+    );
+  }
+
+  /// Map task type to color, need clear taskType before logic returns anything but general color.
+  Color _getTaskColor(String type) {
+    final key = type.toLowerCase();
+    return taskTypeColors[key] ?? Colors.deepOrange;
+  }
+
+  /// Helper to render a day cell with border + task dots
+  Widget _buildDayCell(DateTime day, List<Task> dayTasks, Color borderColor) {
+    const maxVisibleDots = 5;
+    List<Widget> taskDots = [];
+
+    final displayTasks = dayTasks.take(maxVisibleDots).toList();
+    for (var _ in displayTasks) {
+      taskDots.add(
+        Container(
+          width: 8,
+          height: 8,
+          margin: const EdgeInsets.symmetric(horizontal: 1, vertical: 1),
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            //TODO Need to figure out better system for checking colors if needed.
+            color: _getTaskColor("general"),
+          ),
+        ),
+      );
+    }
+
+    if (dayTasks.length > maxVisibleDots) {
+      taskDots.add(
+        Text(
+          '+${dayTasks.length - maxVisibleDots}',
+          style: const TextStyle(fontSize: 8),
+        ),
+      );
+    }
+
+    return SizedBox(
+      height: 90, // taller cells
+      child: Container(
+        padding: const EdgeInsets.all(4),
+        decoration: BoxDecoration(
+          border: Border.all(color: borderColor, width: 1),
+          borderRadius: BorderRadius.circular(6),
+        ),
+        alignment: Alignment.topCenter,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: [
+            Text("${day.day}"),
+            const SizedBox(height: 4),
+            Wrap(
+              spacing: 2,
+              runSpacing: 2,
+              alignment: WrapAlignment.center,
+              children: taskDots,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  //CRUD Fucntion for adding tasks through this display
+  //Tasks can be added to the system through other features and will appear in the Calendar
+  Future<void> _addTask() async {
+    final user = Provider.of<UserProvider>(context, listen: false).user;
+    if (user == null) return;
+
+    final titleController = TextEditingController();
+    final descriptionController = TextEditingController();
+    TimeOfDay? selectedTime;
+    //Pop Up form for basic information to make a task
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setState) => Dialog(
+            //Padding and sizing set for control of viewable pop up space and to ensre
+            //form fields are not spawened  to top of each other.
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextField(
+                    controller: titleController,
+                    decoration: const InputDecoration(labelText: "Task Title"),
+                  ),
+                  const SizedBox(height: 8),
+                  TextField(
+                    controller: descriptionController,
+                    decoration: const InputDecoration(labelText: "Description"),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Text(
+                        selectedTime != null
+                            ? "Time: ${selectedTime!.format(context)}"
+                            : "Time: Not set",
+                      ),
+                      const Spacer(),
+                      TextButton(
+                        onPressed: () async {
+                          final picked = await showTimePicker(
+                            context: context,
+                            initialTime: TimeOfDay.now(),
+                          );
+                          if (picked != null) {
+                            setState(() {
+                              selectedTime = picked;
+                            });
+                          }
+                        },
+                        child: const Text("Pick Time"),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(context, false),
+                        child: const Text("Cancel"),
+                      ),
+                      ElevatedButton(
+                        onPressed: () => Navigator.pop(context, true),
+                        child: const Text("Save"),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+
+    if (confirmed != true) return;
+
+    final patientId = user.id;
+
+    final newTaskJson = {
+      'id': -1,
+      'name': titleController.text,
+      'description': descriptionController.text,
+      'date': (_selectedDay ?? DateTime.now()).toIso8601String(),
+      'timeOfDay': selectedTime != null
+          ? '${selectedTime!.hour.toString().padLeft(2, '0')}:${selectedTime!.minute.toString().padLeft(2, '0')}'
+          : null,
+      //For now this is ignored until the endpoint is updated
+      'userId': patientId,
+    };
+
+    try {
+      final response = await ApiService.createTask(
+        patientId,
+        jsonEncode(newTaskJson),
+      );
+      //Add message sent if good response then make sure the class updates from DB
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        await _loadTasksFromDb();
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text("Task added successfully")),
+        );
+      } else {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text("Failed to add task: ${response.statusCode}")),
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text("Error adding task: $e")));
+    }
+  }
+
+  //CRUD Fucntion for editing tasks through this display
+  //Tasks can be edited to the system through other features and will appear in the Calendar
+  Future<void> _editTask(Task task) async {
+    final user = Provider.of<UserProvider>(context, listen: false).user;
+    if (user == null) return;
+
+    final titleController = TextEditingController(text: task.name);
+    final descriptionController = TextEditingController(text: task.description);
+    TimeOfDay? selectedTime = task.timeOfDay;
+
+    int? selectedPatientId = task.userId;
+
+    // If caregiver, fetch their patients for dropdown
+    List<Map<String, dynamic>> patients = [];
+    if (user.isCaregiver) {
+      final response = await ApiService.getCaregiverPatients(user.id);
+      if (response.statusCode == 200) {
+        patients = List<Map<String, dynamic>>.from(jsonDecode(response.body));
+      }
+    }
+    if (!mounted) return;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setState) => AlertDialog(
+            title: const Text("Edit Task"),
+            content: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 12.0),
+                    child: TextField(
+                      controller: titleController,
+                      decoration: const InputDecoration(
+                        labelText: "Task Title",
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                  ),
+
+                  // Description field
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 12.0),
+                    child: TextField(
+                      controller: descriptionController,
+                      maxLines:
+                          3, //Allows multiline so text doesn’t get cramped
+                      decoration: const InputDecoration(
+                        labelText: "Description",
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                  ),
+
+                  const SizedBox(height: 12),
+
+                  // Time picker
+                  Row(
+                    children: [
+                      const Text("Time: "),
+                      Text(
+                        selectedTime != null
+                            ? "${selectedTime!.hour.toString().padLeft(2, '0')}:${selectedTime!.minute.toString().padLeft(2, '0')}"
+                            : "Not set",
+                      ),
+                      const Spacer(),
+                      ElevatedButton(
+                        onPressed: () async {
+                          final picked = await showTimePicker(
+                            context: context,
+                            initialTime: selectedTime ?? TimeOfDay.now(),
+                          );
+                          if (picked != null) {
+                            setState(() {
+                              selectedTime = picked;
+                            });
+                          }
+                        },
+                        child: const Text("Pick Time"),
+                      ),
+                    ],
+                  ),
+
+                  const SizedBox(height: 12),
+
+                  // Caregiver can reassign task
+                  if (user.isPatient)
+                    Text("Assigned to: ${user.name}")
+                  else if (user.isCaregiver)
+                    DropdownButtonFormField<int>(
+                      decoration: const InputDecoration(
+                        labelText: "Assign to Patient",
+                        border: OutlineInputBorder(),
+                      ),
+                      //This portion of the create menu is blocked by limitations of the endpoint for now.
+                      initialValue: selectedPatientId,
+                      items: patients.map((p) {
+                        return DropdownMenuItem<int>(
+                          value: p['patient']?['id'],
+                          child: Text(
+                            "${p['patient']?['firstName']} ${p['patient']?['lastName']}",
+                          ),
+                        );
+                      }).toList(),
+                      onChanged: (val) {
+                        setState(() {
+                          selectedPatientId = val;
+                        });
+                      },
+                    ),
+                ],
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: const Text("Cancel"),
+              ),
+              ElevatedButton(
+                onPressed: () {
+                  if (user.isCaregiver && selectedPatientId == null) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text("Please select a patient")),
+                    );
+                    return;
+                  }
+                  Navigator.pop(context, true);
+                },
+                child: const Text("Save"),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+
+    if (confirmed != true) return;
+    // deciding logic for patient id based on user
+    final patientId = user.isPatient ? user.id : selectedPatientId!;
+
+    // Build updated task object
+    final updatedTask = Task(
+      id: task.id,
+      name: titleController.text,
+      description: descriptionController.text,
+      date: task.date,
+      timeOfDay: selectedTime,
+      userId: patientId,
+      isComplete: task.isComplete,
+      notifications: task.notifications,
+      frequency: task.frequency,
+      interval: task.interval,
+      count: task.count,
+      daysOfWeek: task.daysOfWeek,
+    );
+
+    try {
+      final response = await ApiService.editTask(task.id, updatedTask.toJson());
+
+      //Edit message sent if good response then make sure the class updates from DB
+      if (response.statusCode == 200) {
+        await _loadTasksFromDb();
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text("Task updated successfully")),
+        );
+      } else {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text("Failed to edit task: ${response.statusCode}"),
+          ),
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text("Error editing task: $e")));
+    }
+  }
+
+  //CRUD Fucntion for removing tasks through this display
+  //Tasks can be removed to the system through other features and will appear in the Calendar
+  Future<void> _removeTask(Task task) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text("Confirm Delete"),
+          content: Text("Are you sure you want to delete '${task.name}'?"),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text("Cancel"),
+            ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text("Delete"),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (confirmed != true) return;
+
+    try {
+      final response = await ApiService.deleteTask(task.id);
+      //Removal message sent if good response then make sure the class updates from DB
+      if (response.statusCode == 200 || response.statusCode == 204) {
+        await _loadTasksFromDb();
+        if (!mounted) return;
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text("Task '${task.name}' removed")));
+      } else {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text("Failed to delete task: ${response.statusCode}"),
+          ),
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text("Error deleting task: $e")));
+    }
+  }
+}

--- a/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
@@ -1,9 +1,9 @@
-// Class: CalendarAssistantScreen
-// Descritpion: Running the Calendar Assistant through notification and task systems of CareConnect
+// =============================
+// CalendarAssistantScreen.dart
+// =============================
 
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:developer';
 
 import 'package:care_connect_app/features/tasks/models/task_model.dart';
 import 'package:care_connect_app/providers/user_provider.dart';
@@ -14,6 +14,206 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:table_calendar/table_calendar.dart';
 
+extension TaskCopyWith on Task {
+  Task copyWith({
+    int? id,
+    String? name,
+    String? description,
+    DateTime? date,
+    TimeOfDay? timeOfDay,
+    int? userId,
+    bool? isComplete,
+    String? frequency,
+    int? interval,
+    int? count,
+    List<bool>? daysOfWeek,
+    String? taskType,
+  }) {
+    return Task(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      description: description ?? this.description,
+      date: date ?? this.date,
+      timeOfDay: timeOfDay ?? this.timeOfDay,
+      userId: userId ?? this.userId,
+      isComplete: isComplete ?? this.isComplete,
+      notifications: this.notifications, // keep existing notifications
+      frequency: frequency ?? this.frequency,
+      interval: interval ?? this.interval,
+      count: count ?? this.count,
+      daysOfWeek: daysOfWeek ?? this.daysOfWeek,
+      taskType: taskType ?? this.taskType,
+    );
+  }
+}
+
+/// Utilities for task normalization & grouping
+class TaskUtils {
+  static Map<String, dynamic> normalizeTaskMap(Map<String, dynamic> map) {
+    if (map['date'] is String) {
+      final d = map['date'];
+      if (!d.contains('T')) map['date'] = d.replaceFirst(' ', 'T');
+    }
+    final dow = map['daysOfWeek'];
+    if (dow is String) {
+      try {
+        map['daysOfWeek'] = List<bool>.from(jsonDecode(dow));
+      } catch (_) {
+        map['daysOfWeek'] = [];
+      }
+    }
+    if (map['isComplete'] == null && map['completed'] != null) {
+      map['isComplete'] = map['completed'];
+    }
+    return map;
+  }
+
+  static LinkedHashMap<DateTime, List<Task>> groupTasksByDate(
+    List<Task> tasks,
+  ) {
+    final grouped = LinkedHashMap<DateTime, List<Task>>(
+      equals: isSameDay,
+      hashCode: (date) => date.day * 1000000 + date.month * 10000 + date.year,
+    );
+
+    for (final task in tasks) {
+      final key = DateTime(task.date.year, task.date.month, task.date.day);
+
+      // Deduplicate by (task.id + task.date)
+      final existing = grouped.putIfAbsent(key, () => []);
+      if (!existing.any((t) => t.id == task.id && t.date == task.date)) {
+        existing.add(task);
+      }
+    }
+    return grouped;
+  }
+}
+
+/// Utilities for building recurring tasks consistently
+class RecurrenceUtils {
+  static Task buildTask({
+    required Task baseTask,
+    bool? isRecurring,
+    String? recurrenceType, // "Daily", "Weekly", "Monthly", "Yearly"
+    List<bool>? daysOfWeek,
+    int? interval,
+    int? count,
+    DateTime? startDate,
+    DateTime? endDate,
+    int? dayOfMonth,
+  }) {
+    String? frequency;
+    String? taskType;
+    int? intervalToSend = interval;
+    int? countToSend = count;
+
+    // Default effective start date
+    DateTime effectiveDate = startDate ?? baseTask.date;
+
+    if (isRecurring == true && recurrenceType != null) {
+      switch (recurrenceType.toLowerCase()) {
+        case "daily":
+          frequency = "daily";
+          intervalToSend = (intervalToSend == null || intervalToSend < 1)
+              ? 1
+              : intervalToSend;
+
+          if (endDate != null) {
+            final daysBetween = endDate.difference(effectiveDate).inDays;
+            countToSend = (daysBetween ~/ intervalToSend) + 1;
+          } else {
+            countToSend ??= 30; // fallback: 30 days if no end date
+          }
+          taskType = "frequency";
+          break;
+
+        case "weekly":
+          frequency = "weekly";
+          intervalToSend = (intervalToSend == null || intervalToSend < 1)
+              ? 1
+              : intervalToSend;
+
+          if (endDate != null) {
+            final totalWeeks =
+                (endDate.difference(effectiveDate).inDays ~/ 7) + 1;
+
+            if (daysOfWeek != null && daysOfWeek.any((d) => d)) {
+              final selectedDays = daysOfWeek.where((d) => d).length;
+              countToSend = totalWeeks * selectedDays;
+              taskType = "dayOfWeek";
+            } else {
+              countToSend = totalWeeks;
+              taskType = "frequency";
+            }
+          } else {
+            countToSend ??= 4; // default 4 weeks if no end date
+            taskType = "frequency";
+          }
+          break;
+
+        case "monthly":
+          frequency = "monthly";
+          intervalToSend = (intervalToSend == null || intervalToSend < 1)
+              ? 1
+              : intervalToSend;
+
+          if (dayOfMonth != null) {
+            final daysInMonth = DateUtils.getDaysInMonth(
+              effectiveDate.year,
+              effectiveDate.month,
+            );
+            final dom = dayOfMonth.clamp(1, daysInMonth);
+            effectiveDate = DateTime(
+              effectiveDate.year,
+              effectiveDate.month,
+              dom,
+            );
+          }
+
+          if (endDate != null) {
+            final months =
+                (endDate.year - effectiveDate.year) * 12 +
+                (endDate.month - effectiveDate.month);
+            countToSend = (months ~/ intervalToSend!) + 1;
+          } else {
+            countToSend ??= 12; // default: 12 months
+          }
+
+          taskType = "frequency";
+          break;
+
+        case "yearly":
+          frequency = "yearly";
+          intervalToSend = (intervalToSend == null || intervalToSend < 1)
+              ? 1
+              : intervalToSend;
+
+          if (endDate != null) {
+            final years = endDate.year - effectiveDate.year;
+            countToSend = (years ~/ intervalToSend) + 1;
+          } else {
+            countToSend ??= 5; // default: 5 years
+          }
+
+          taskType = "frequency";
+          break;
+      }
+    }
+
+    return baseTask.copyWith(
+      date: effectiveDate,
+      frequency: frequency,
+      interval: intervalToSend,
+      count: countToSend,
+      daysOfWeek: daysOfWeek,
+      taskType: taskType,
+    );
+  }
+}
+
+/// =============================
+/// Calendar Assistant Screen
+/// =============================
 class CalendarAssistantScreen extends StatefulWidget {
   const CalendarAssistantScreen({super.key});
 
@@ -23,24 +223,17 @@ class CalendarAssistantScreen extends StatefulWidget {
 }
 
 class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
-  //State variables for loading status and if errors have occured.
   bool isLoading = true;
   String? error;
-
-  //Variables used throughout the  class for day selections of the user.
   late DateTime _focusedDay;
   DateTime? _selectedDay;
 
-  /// Store tasks grouped by day (with isSameDay logic)
   Map<DateTime, List<Task>> tasks = LinkedHashMap(
     equals: isSameDay,
     hashCode: (date) => date.day * 1000000 + date.month * 10000 + date.year,
   );
-
-  // Map patientId -> patient name
   Map<int, String> patientNames = {};
 
-  // Define task types and their colors
   final Map<String, Color> taskTypeColors = {
     'medication': Colors.red,
     'appointment': Colors.blue,
@@ -51,312 +244,13 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     'medical': Colors.cyan,
   };
 
-  @override
-  void initState() {
-    super.initState();
-    _focusedDay = DateTime.now();
-    _loadTasksFromDb();
+  /// Map task type to color
+  Color _getTaskColor(String type) {
+    final key = type.toLowerCase();
+    return taskTypeColors[key] ?? Colors.deepOrange;
   }
 
-  //Function for making sure the Calendar displayed has updated DB information
-
-  Future<void> _loadTasksFromDb() async {
-    setState(() {
-      isLoading = true;
-      error = null;
-    });
-
-    log("🛰️ Starting DB Query");
-
-    try {
-      final user = Provider.of<UserProvider>(context, listen: false).user;
-      if (user == null) {
-        setState(() {
-          error = "User not logged in.";
-          isLoading = false;
-        });
-        return;
-      }
-
-      final List<Task> allTasks = [];
-      if (user.isCaregiver) {
-        // refresh patient name map each load
-        patientNames.clear();
-      }
-
-      // Helper to normalize a raw map before Task.fromJson
-      Map<String, dynamic> normalizeTaskMap(Map<String, dynamic> map) {
-        // Normalize date string and keep it ISO-like
-        if (map['date'] != null && map['date'] is String) {
-          final d = map['date'] as String;
-          // ensure ISO separator
-          if (!d.contains('T')) {
-            map['date'] = d.replaceFirst(' ', 'T');
-          }
-        }
-
-        // Normalize daysOfWeek to List<bool>
-        final dow = map['daysOfWeek'];
-        if (dow == null || dow == "null") {
-          map['daysOfWeek'] = [];
-        } else if (dow is String) {
-          try {
-            map['daysOfWeek'] = List<bool>.from(jsonDecode(dow));
-          } catch (_) {
-            map['daysOfWeek'] = [];
-          }
-        }
-
-        // Accept both 'isComplete' and 'completed'
-        if (map['isComplete'] == null && map['completed'] != null) {
-          map['isComplete'] = map['completed'];
-        }
-
-        return map;
-      }
-
-      // --- PATIENT FLOW ---
-      if (user.isPatient) {
-        print("🛰️ In the patient flow");
-        final response = await ApiService.getPatientTasksV2(
-          user.id,
-        ).timeout(const Duration(seconds: 30));
-        if (response.statusCode == 200) {
-          final List data = json.decode(response.body);
-          for (final raw in data) {
-            final map = normalizeTaskMap(Map<String, dynamic>.from(raw));
-            try {
-              final baseTask = Task.fromJson(map);
-              // Ensure local time normalization
-              baseTask.date = baseTask.date.toLocal();
-              final expandedOccurrences = baseTask.expandOccurrences();
-              print(
-                "📅 Expanded ${baseTask.name}: ${expandedOccurrences.length} occurrences",
-              );
-              allTasks.addAll(expandedOccurrences);
-            } catch (e) {
-              log("Error parsing task: $e");
-            }
-          }
-        }
-      }
-      // --- CAREGIVER FLOW ---
-      else if (user.isCaregiver) {
-        print("🛰️ In care giverflow");
-        final patientsResponse = await ApiService.getCaregiverPatients(user.id);
-        if (patientsResponse.statusCode == 200) {
-          final List patients = json.decode(patientsResponse.body);
-
-          for (final patient in patients) {
-            final pid = patient['patient']?['id'];
-            final firstName = patient['patient']?['firstName'] ?? '';
-            final lastName = patient['patient']?['lastName'] ?? '';
-
-            if (pid != null) {
-              patientNames[pid] = "$firstName $lastName".trim();
-            }
-            if (pid == null) continue;
-
-            final taskResponse = await ApiService.getPatientTasksV2(
-              pid,
-            ).timeout(const Duration(seconds: 30));
-            if (taskResponse.statusCode == 200) {
-              print("🛰️ Response body: ${taskResponse.body}");
-              final List data = json.decode(taskResponse.body);
-              for (final raw in data) {
-                final map = normalizeTaskMap(Map<String, dynamic>.from(raw));
-                try {
-                  final task = Task.fromJson(map);
-                  task.date = task.date.toLocal(); // UTC → local
-                  final expanded = task.expandOccurrences();
-                  print(
-                    "📅 Expanded ${task.name}: ${expanded.length} occurrences",
-                  );
-                  for (var occ in expanded) {
-                    print("   -> ${occ.date}");
-                  }
-                  allTasks.addAll(task.expandOccurrences());
-                } catch (e) {
-                  log("Error parsing caregiver task: $e");
-                }
-              }
-            }
-          }
-        }
-      }
-
-      // --- GROUP TASKS BY DATE ---
-      final grouped = LinkedHashMap<DateTime, List<Task>>(
-        equals: isSameDay,
-        hashCode: (date) => date.day * 1000000 + date.month * 10000 + date.year,
-      );
-
-      for (final task in allTasks) {
-        final key = DateTime(task.date.year, task.date.month, task.date.day);
-        print("📌 Grouping task ${task.name} on $key");
-        grouped.putIfAbsent(key, () => []).add(task);
-      }
-      print("📊 Final grouped keys:");
-      grouped.forEach((k, v) {
-        print("   $k -> ${v.length} tasks");
-      });
-
-      if (!mounted) return;
-      setState(() {
-        tasks = grouped;
-        isLoading = false;
-      });
-    } catch (e) {
-      if (!mounted) return;
-      setState(() {
-        error = "Error: $e";
-        isLoading = false;
-      });
-    }
-  }
-
-  //Things in UI functions succh as dart may need to be updated to match new UI requirements.
-  @override
-  Widget build(BuildContext context) {
-    if (isLoading) {
-      return Scaffold(
-        drawer: const CommonDrawer(currentRoute: '/calendar'),
-        appBar: AppBarHelper.createAppBar(
-          context,
-          title: 'Calendar Assistant',
-          centerTitle: true,
-        ),
-        body: const Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              CircularProgressIndicator(),
-              SizedBox(height: 16),
-              Text('Loading Calendar ...'),
-            ],
-          ),
-        ),
-      );
-    }
-
-    return Scaffold(
-      drawer: const CommonDrawer(currentRoute: '/calendar'),
-      appBar: AppBarHelper.createAppBar(
-        context,
-        title: 'Calendar Assistant',
-        centerTitle: true,
-        additionalActions: [
-          TextButton.icon(
-            icon: const Icon(Icons.add, color: Colors.white),
-            label: const Text(
-              "Add Task",
-              style: TextStyle(color: Colors.white),
-            ),
-            onPressed: _addTask,
-          ),
-        ],
-      ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          child: Column(
-            children: [
-              TableCalendar<Task>(
-                firstDay: DateTime.utc(2020, 1, 1),
-                lastDay: DateTime.utc(2030, 12, 31),
-                focusedDay: _focusedDay,
-                selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
-                eventLoader: (day) {
-                  final key = DateTime(
-                    day.year,
-                    day.month,
-                    day.day,
-                  ); // normalize to midnight
-                  return tasks[key] ?? [];
-                },
-                onDaySelected: (selectedDay, focusedDay) {
-                  setState(() {
-                    _selectedDay = selectedDay;
-                    _focusedDay = focusedDay;
-                  });
-                },
-                rowHeight: 100,
-                calendarFormat: CalendarFormat.month,
-                availableCalendarFormats: const {CalendarFormat.month: 'Month'},
-                calendarStyle: const CalendarStyle(markersMaxCount: 0),
-                headerVisible: true,
-                calendarBuilders: CalendarBuilders(
-                  defaultBuilder: (context, day, focusedDay) {
-                    final dayTasks = tasks[day] ?? [];
-                    return _buildDayCell(day, dayTasks, Colors.grey);
-                  },
-                  todayBuilder: (context, day, focusedDay) {
-                    final dayTasks = tasks[day] ?? [];
-                    return _buildDayCell(day, dayTasks, Colors.blue);
-                  },
-                  selectedBuilder: (context, day, focusedDay) {
-                    final dayTasks = tasks[day] ?? [];
-                    return _buildDayCell(day, dayTasks, Colors.green);
-                  },
-                ),
-              ),
-
-              const SizedBox(height: 16),
-              // Task list with edit/remove buttons
-              if (_selectedDay != null && tasks[_selectedDay] != null)
-                ...tasks[_selectedDay]!.map((task) {
-                  final assignedName = task.userId != null
-                      ? patientNames[task.userId] ?? "Unknown Patient"
-                      : "Unassigned";
-
-                  return ListTile(
-                    leading: const Icon(Icons.task),
-                    title: Text(
-                      "$assignedName: ${task.name}",
-                      style: const TextStyle(fontWeight: FontWeight.w500),
-                    ),
-                    trailing: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        IconButton(
-                          icon: const Icon(Icons.edit, color: Colors.blue),
-                          tooltip: 'Edit Task',
-                          onPressed: () => _editTask(task),
-                        ),
-                        IconButton(
-                          icon: const Icon(Icons.delete, color: Colors.red),
-                          tooltip: 'Remove Task',
-                          onPressed: () => _removeTask(task),
-                        ),
-                      ],
-                    ),
-                  );
-                })
-              else
-                const Padding(
-                  padding: EdgeInsets.all(16.0),
-                  child: Text("Select a day to view tasks"),
-                ),
-
-              const SizedBox(height: 16),
-
-              // Legend
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Wrap(
-                  spacing: 16,
-                  children: taskTypeColors.entries
-                      .map((e) => _buildLegendDot(e.value, e.key))
-                      .toList(),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  //Function builds color legend based on available colors defined
+  /// Build a small colored dot + label for the legend
   Widget _buildLegendDot(Color color, String label) {
     return Row(
       mainAxisSize: MainAxisSize.min,
@@ -372,20 +266,13 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     );
   }
 
-  /// Map task type to color
-  Color _getTaskColor(String type) {
-    final key = type.toLowerCase();
-    return taskTypeColors[key] ?? Colors.deepOrange;
-  }
-
-  /// Helper to render a day cell with border + task dots
+  /// Render a day cell with border + colored dots for tasks
   Widget _buildDayCell(DateTime day, List<Task> dayTasks, Color borderColor) {
     const maxVisibleDots = 5;
-    List<Widget> taskDots = [];
-
     final displayTasks = dayTasks.take(maxVisibleDots).toList();
-    for (var task in displayTasks) {
-      taskDots.add(
+
+    final taskDots = [
+      for (var task in displayTasks)
         Container(
           width: 8,
           height: 8,
@@ -395,20 +282,15 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
             color: _getTaskColor(task.taskType ?? "general"),
           ),
         ),
-      );
-    }
-
-    if (dayTasks.length > maxVisibleDots) {
-      taskDots.add(
+      if (dayTasks.length > maxVisibleDots)
         Text(
           '+${dayTasks.length - maxVisibleDots}',
           style: const TextStyle(fontSize: 8),
         ),
-      );
-    }
+    ];
 
     return SizedBox(
-      height: 90, // taller cells
+      height: 90,
       child: Container(
         padding: const EdgeInsets.all(4),
         decoration: BoxDecoration(
@@ -421,49 +303,275 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
           children: [
             Text("${day.day}"),
             const SizedBox(height: 4),
-            Wrap(
-              spacing: 2,
-              runSpacing: 2,
-              alignment: WrapAlignment.center,
-              children: taskDots,
-            ),
+            Wrap(spacing: 2, runSpacing: 2, children: taskDots),
           ],
         ),
       ),
     );
   }
 
-  //CRUD Fucntion for adding tasks through this display
-  //Tasks can be added to the system through other features and will appear in the Calendar
+  @override
+  void initState() {
+    super.initState();
+    _focusedDay = DateTime.now();
+    _loadTasksFromDb();
+  }
+
+  Future<void> _loadTasksFromDb() async {
+    setState(() {
+      isLoading = true;
+      error = null;
+    });
+
+    try {
+      final user = Provider.of<UserProvider>(context, listen: false).user;
+      if (user == null) {
+        setState(() {
+          error = "User not logged in.";
+          isLoading = false;
+        });
+        return;
+      }
+
+      final List<Task> allTasks = [];
+
+      if (user.isPatient) {
+        allTasks.addAll(await _fetchTasksForPatient(user.id));
+      } else if (user.isCaregiver) {
+        patientNames.clear();
+        final patientsResponse = await ApiService.getCaregiverPatients(user.id);
+        if (patientsResponse.statusCode == 200) {
+          final patients = json.decode(patientsResponse.body);
+          for (final patient in patients) {
+            final pid = patient['patient']?['id'];
+            if (pid != null) {
+              patientNames[pid] =
+                  "${patient['patient']?['firstName']} ${patient['patient']?['lastName']}";
+              allTasks.addAll(await _fetchTasksForPatient(pid));
+            }
+          }
+        }
+      }
+
+      setState(() {
+        tasks = TaskUtils.groupTasksByDate(allTasks);
+        isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        error = "Error: $e";
+        isLoading = false;
+      });
+    }
+  }
+
+  Future<List<Task>> _fetchTasksForPatient(int patientId) async {
+    final tasks = <Task>[];
+
+    try {
+      final response = await ApiService.getPatientTasksV2(patientId);
+      if (response.statusCode == 200) {
+        final List data = jsonDecode(response.body);
+
+        for (final raw in data) {
+          final map = TaskUtils.normalizeTaskMap(
+            Map<String, dynamic>.from(raw),
+          );
+
+          try {
+            final baseTask = Task.fromJson(map);
+            baseTask.date = baseTask.date.toLocal();
+
+            // Expand recurrences
+            final expanded = baseTask.expandOccurrences();
+            tasks.addAll(expanded);
+          } catch (e) {
+            debugPrint("Error parsing task for patient $patientId: $e");
+          }
+        }
+      } else {
+        debugPrint(
+          "Failed to fetch tasks for patient $patientId: ${response.statusCode}",
+        );
+      }
+    } catch (e) {
+      debugPrint("Exception while fetching tasks for patient $patientId: $e");
+    }
+
+    return tasks;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (isLoading) {
+      return Scaffold(
+        drawer: const CommonDrawer(currentRoute: '/calendar'),
+        appBar: AppBarHelper.createAppBar(context, title: 'Calendar Assistant'),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    return Scaffold(
+      drawer: const CommonDrawer(currentRoute: '/calendar'),
+      appBar: AppBarHelper.createAppBar(
+        context,
+        title: 'Calendar Assistant',
+        additionalActions: [
+          TextButton.icon(
+            icon: const Icon(Icons.add, color: Colors.white),
+            label: const Text(
+              "Add Task",
+              style: TextStyle(color: Colors.white),
+            ),
+            onPressed: _addTask,
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              // Calendar
+              TableCalendar<Task>(
+                firstDay: DateTime.utc(2020, 1, 1),
+                lastDay: DateTime.utc(2030, 12, 31),
+                focusedDay: _focusedDay,
+                selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
+                eventLoader: (day) =>
+                    tasks[DateTime(day.year, day.month, day.day)] ?? [],
+                onDaySelected: (selectedDay, focusedDay) {
+                  setState(() {
+                    _selectedDay = selectedDay;
+                    _focusedDay = focusedDay;
+                  });
+                },
+                rowHeight: 100,
+                calendarFormat: CalendarFormat.month,
+                availableCalendarFormats: const {CalendarFormat.month: 'Month'},
+                calendarStyle: const CalendarStyle(markersMaxCount: 0),
+                calendarBuilders: CalendarBuilders(
+                  defaultBuilder: (context, day, focusedDay) {
+                    final dayTasks = tasks[day] ?? [];
+                    return _buildDayCell(day, dayTasks, Colors.grey);
+                  },
+                  todayBuilder: (context, day, focusedDay) {
+                    final dayTasks = tasks[day] ?? [];
+                    return _buildDayCell(day, dayTasks, Colors.blue);
+                  },
+                  selectedBuilder: (context, day, focusedDay) {
+                    final dayTasks = tasks[day] ?? [];
+                    return _buildDayCell(day, dayTasks, Colors.green);
+                  },
+                ),
+              ),
+              const SizedBox(height: 16),
+
+              // Legend
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Wrap(
+                  spacing: 16,
+                  children: taskTypeColors.entries
+                      .map((e) => _buildLegendDot(e.value, e.key))
+                      .toList(),
+                ),
+              ),
+              const SizedBox(height: 16),
+
+              // Task list for selected day
+              if (_selectedDay != null && tasks[_selectedDay] != null)
+                Builder(
+                  builder: (_) {
+                    final dayTasks = [...tasks[_selectedDay]!];
+
+                    // ✅ Sort chronologically by timeOfDay
+                    dayTasks.sort((a, b) {
+                      if (a.timeOfDay != null && b.timeOfDay != null) {
+                        final aMinutes =
+                            a.timeOfDay!.hour * 60 + a.timeOfDay!.minute;
+                        final bMinutes =
+                            b.timeOfDay!.hour * 60 + b.timeOfDay!.minute;
+                        return aMinutes.compareTo(bMinutes);
+                      }
+                      if (a.timeOfDay != null) return -1;
+                      if (b.timeOfDay != null) return 1;
+                      return a.name.compareTo(b.name);
+                    });
+
+                    return Column(
+                      children: dayTasks.map((task) {
+                        final assignedName = task.userId != null
+                            ? patientNames[task.userId] ?? "Unknown Patient"
+                            : "Unassigned";
+
+                        return ListTile(
+                          leading: Icon(
+                            Icons.task,
+                            color: _getTaskColor(task.taskType ?? "general"),
+                          ),
+                          title: Text(
+                            task.name,
+                            style: const TextStyle(
+                              fontWeight: FontWeight.w600,
+                              fontSize: 16,
+                            ),
+                          ),
+                          subtitle: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                task.timeOfDay != null
+                                    ? " ${task.timeOfDay!.format(context)}"
+                                    : " All day",
+                              ),
+                              if (assignedName.isNotEmpty &&
+                                  assignedName != "Unassigned")
+                                Text("👤 $assignedName"),
+                            ],
+                          ),
+                          trailing: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              IconButton(
+                                icon: const Icon(
+                                  Icons.edit,
+                                  color: Colors.blue,
+                                ),
+                                tooltip: 'Edit Task',
+                                onPressed: () => _editTask(task),
+                              ),
+                              IconButton(
+                                icon: const Icon(
+                                  Icons.delete,
+                                  color: Colors.red,
+                                ),
+                                tooltip: 'Remove Task',
+                                onPressed: () => _removeTask(task),
+                              ),
+                            ],
+                          ),
+                        );
+                      }).toList(),
+                    );
+                  },
+                )
+              else
+                const Padding(
+                  padding: EdgeInsets.all(16.0),
+                  child: Text("Select a day to view tasks"),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 
   Future<void> _addTask() async {
     final user = Provider.of<UserProvider>(context, listen: false).user;
     if (user == null) return;
 
-    final titleController = TextEditingController();
-    final descriptionController = TextEditingController();
-    TimeOfDay? selectedTime;
-
-    // Default to selected calendar day
-    final selectedDate = DateTime(
-      (_selectedDay ?? _focusedDay).year,
-      (_selectedDay ?? _focusedDay).month,
-      (_selectedDay ?? _focusedDay).day,
-    );
-
-    int? selectedPatientId = user.isPatient ? user.id : null;
-
-    // Local holders for recurrence
-    bool recIsRecurring = false;
-    String? recType;
-    List<bool>? recDaysOfWeek;
-    DateTime? recStartDate;
-    DateTime? recEndDate;
-    int? recInterval;
-    int? recCount;
-    int? recDayOfMonth;
-
-    // If caregiver, fetch patients for dropdown
+    // Preload patients if caregiver
     List<Map<String, dynamic>> patients = [];
     if (user.isCaregiver) {
       final response = await ApiService.getCaregiverPatients(user.id);
@@ -472,301 +580,23 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
       }
     }
 
-    if (!mounted) return;
-    final confirmed = await showDialog<bool>(
+    // Show dialog
+    final draftTask = await showDialog<Task>(
       context: context,
-      builder: (context) {
-        return StatefulBuilder(
-          builder: (context, setState) => AlertDialog(
-            title: const Text("Add Task"),
-            content: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  // Title
-                  TextField(
-                    controller: titleController,
-                    decoration: const InputDecoration(
-                      labelText: "Task Title",
-                      border: OutlineInputBorder(),
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-
-                  // Description
-                  TextField(
-                    controller: descriptionController,
-                    maxLines: 3,
-                    decoration: const InputDecoration(
-                      labelText: "Description",
-                      border: OutlineInputBorder(),
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-
-                  // Time picker
-                  Row(
-                    children: [
-                      const Text("Time: "),
-                      Text(
-                        selectedTime != null
-                            ? "${selectedTime!.hour.toString().padLeft(2, '0')}:${selectedTime!.minute.toString().padLeft(2, '0')}"
-                            : "Not set",
-                      ),
-                      const Spacer(),
-                      ElevatedButton(
-                        onPressed: () async {
-                          final picked = await showTimePicker(
-                            context: context,
-                            initialTime: selectedTime ?? TimeOfDay.now(),
-                          );
-                          if (picked != null) {
-                            setState(() => selectedTime = picked);
-                          }
-                        },
-                        child: const Text("Pick Time"),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 12),
-
-                  // Caregiver assignment dropdown
-                  if (user.isPatient)
-                    Text("Assigned to: ${user.name}")
-                  else if (user.isCaregiver)
-                    DropdownButtonFormField<int>(
-                      decoration: const InputDecoration(
-                        labelText: "Assign to Patient",
-                        border: OutlineInputBorder(),
-                      ),
-                      value: selectedPatientId,
-                      items: patients.map((p) {
-                        return DropdownMenuItem<int>(
-                          value: p['patient']?['id'],
-                          child: Text(
-                            "${p['patient']?['firstName']} ${p['patient']?['lastName']}",
-                          ),
-                        );
-                      }).toList(),
-                      onChanged: (val) {
-                        setState(() => selectedPatientId = val);
-                      },
-                    ),
-
-                  const SizedBox(height: 16),
-
-                  // Recurrence form
-                  RecurrenceForm(
-                    onChanged:
-                        ({
-                          bool? isRecurring,
-                          String? recurrenceType,
-                          List<bool>? daysOfWeek,
-                          int? interval,
-                          int? count,
-                          DateTime? startDate,
-                          DateTime? endDate,
-                          int? dayOfMonth,
-                        }) {
-                          setState(() {
-                            // update local state for validation
-                            recIsRecurring = isRecurring ?? false;
-                            recType = recurrenceType;
-                          });
-
-                          recType = recurrenceType;
-                          recDaysOfWeek = daysOfWeek;
-                          recInterval = interval;
-                          recCount = count;
-                          recStartDate = startDate;
-                          recEndDate = endDate;
-                          recDayOfMonth = dayOfMonth;
-                        },
-                  ),
-                ],
-              ),
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(context, false),
-                child: const Text("Cancel"),
-              ),
-              ElevatedButton(
-                onPressed:
-                    (recIsRecurring && (recType == null || recType!.isEmpty))
-                    ? null //disable if recurring but no type
-                    : () {
-                        if (user.isCaregiver && selectedPatientId == null) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text("Please select a patient"),
-                            ),
-                          );
-                          return;
-                        }
-                        Navigator.pop(context, true);
-                      },
-                child: const Text("Save"),
-              ),
-            ],
-          ),
-        );
-      },
+      builder: (_) => TaskFormDialog(
+        isCaregiver: user.isCaregiver,
+        patients: patients,
+        defaultPatientId: user.isPatient ? user.id : null,
+      ),
     );
 
-    if (confirmed != true) return;
-    DateTime effectiveDate = selectedDate;
-    final patientId = user.isPatient ? user.id : selectedPatientId!;
-    // Calculate recurrence fields if recurring
-    if (recIsRecurring && recType != null && recEndDate != null) {
-      switch (recType!.toLowerCase()) {
-        case "daily":
-          recInterval = (recInterval == null || recInterval! < 1)
-              ? 1
-              : recInterval;
-          final DateTime baseStart = recStartDate ?? selectedDate;
-          recCount ??=
-              (recEndDate!.difference(baseStart).inDays ~/ recInterval!) + 1;
-          break;
-        case "weekly":
-          recInterval = (recInterval == null || recInterval! < 1)
-              ? 1
-              : recInterval;
-          if (recDaysOfWeek != null && recDaysOfWeek!.contains(true)) {
-            int totalWeeks =
-                recEndDate!.difference(selectedDate).inDays ~/ 7 + 1;
-            int selectedDays = recDaysOfWeek!.where((d) => d).length;
-            recCount ??= totalWeeks * selectedDays;
-          } else {
-            recCount ??= recEndDate!.difference(selectedDate).inDays ~/ 7 + 1;
-          }
-          break;
+    if (draftTask == null) return;
 
-        case "monthly":
-          recInterval = (recInterval == null || recInterval! < 1)
-              ? 1
-              : recInterval;
-          int months =
-              (recEndDate!.year - selectedDate.year) * 12 +
-              (recEndDate!.month - selectedDate.month) +
-              1;
-          recCount ??= months;
-          break;
+    final newTask = RecurrenceUtils.buildTask(baseTask: draftTask);
 
-        case "yearly":
-          recInterval = (recInterval == null || recInterval! < 1)
-              ? 1
-              : recInterval;
-          if (recStartDate != null && recEndDate != null) {
-            // Use only the year difference regardless of month/day
-            final startYear = recStartDate!.year;
-            final endYear = recEndDate!.year;
-
-            recCount = (endYear - startYear) + 1;
-
-            // Ensure effectiveDate is set to the correct day/month from startDate
-            effectiveDate = DateTime(
-              startYear,
-              recStartDate!.month,
-              recStartDate!.day,
-            );
-          } else {
-            recCount ??= 5; // fallback default
-          }
-          break;
-      }
-    }
-
-    // Override base date if monthly recurrence specifies a day-of-month
-
-    if (recStartDate != null) {
-      effectiveDate = recStartDate!;
-    }
-
-    if (recType?.toLowerCase() == "monthly" && recEndDate != null) {
-      final daysInMonth = DateUtils.getDaysInMonth(
-        selectedDate.year,
-        selectedDate.month,
-      );
-      final dom = recDayOfMonth!.clamp(1, daysInMonth);
-      effectiveDate = DateTime(selectedDate.year, selectedDate.month, dom);
-    }
-
-    // Normalize recurrence fields
-    String? frequencyToSend;
-    String? taskTypeToSend;
-    int? intervalToSend = recInterval;
-    int? countToSend = recCount;
-
-    if (recIsRecurring && recType != null) {
-      switch (recType!.toLowerCase()) {
-        case "daily":
-          frequencyToSend = "daily";
-          intervalToSend = 1;
-          countToSend = (countToSend == null || countToSend < 1)
-              ? ((recEndDate != null)
-                    ? recEndDate!.difference(selectedDate).inDays + 1
-                    : 30) // default 30
-              : countToSend;
-          taskTypeToSend = "frequency";
-          break;
-
-        case "weekly":
-          frequencyToSend = "weekly";
-          intervalToSend = (intervalToSend == null || intervalToSend < 1)
-              ? 1
-              : intervalToSend;
-          countToSend ??= 4; // default 4 weeks
-          taskTypeToSend =
-              (recDaysOfWeek != null && recDaysOfWeek!.any((e) => e))
-              ? "dayOfWeek"
-              : "frequency";
-          break;
-
-        case "monthly":
-          frequencyToSend = "monthly";
-          intervalToSend = (intervalToSend == null || intervalToSend < 1)
-              ? 1
-              : intervalToSend;
-          countToSend ??= 12;
-          taskTypeToSend = "frequency";
-          break;
-
-        case "yearly":
-          frequencyToSend = "yearly";
-          intervalToSend = (intervalToSend == null || intervalToSend < 1)
-              ? 1
-              : intervalToSend;
-          countToSend = (countToSend == null || countToSend < 1)
-              ? 5
-              : countToSend;
-          taskTypeToSend = "frequency";
-          break;
-      }
-    }
-    // Build new task object
-    final newTask = Task(
-      id: -1,
-      name: titleController.text,
-      description: descriptionController.text,
-      date: effectiveDate,
-      timeOfDay: selectedTime,
-      userId: patientId,
-      isComplete: false,
-      notifications: null,
-      frequency: frequencyToSend,
-      interval: intervalToSend,
-      count: countToSend,
-      daysOfWeek: recDaysOfWeek,
-      taskType: taskTypeToSend,
-    );
-    print(
-      "🧭 Creating task -> freq=$frequencyToSend interval=$intervalToSend count=$countToSend start=$effectiveDate",
-    );
     try {
-      print("🛰️ Response body:  ${jsonEncode(newTask.toJson())}");
       final response = await ApiService.createTaskV2(
-        patientId,
+        newTask.userId!,
         jsonEncode(newTask.toJson()),
       );
 
@@ -790,128 +620,21 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     }
   }
 
-  /// helper function to calculate recurrence count
-  int _calculateCount(
-    String recurrenceType,
-    int interval,
-    DateTime startDate,
-    DateTime endDate, {
-    List<bool>? selectedDays,
-  }) {
-    switch (recurrenceType.toLowerCase()) {
-      case "daily":
-        return endDate.difference(startDate).inDays ~/ interval;
-      case "weekly":
-        if (selectedDays != null && selectedDays.contains(true)) {
-          return _calculateWeeklyOccurrences(startDate, endDate, selectedDays);
-        }
-        return endDate.difference(startDate).inDays ~/ interval;
-      case "monthly":
-        return ((endDate.year - startDate.year) * 12 +
-                endDate.month -
-                startDate.month) ~/
-            1;
-      case "yearly":
-        return endDate.year - startDate.year;
-      default:
-        return 1;
-    }
-  }
-
-  /// helper function to calculate recurrence count per week
-  int _calculateWeeklyOccurrences(
-    DateTime startDate,
-    DateTime endDate,
-    List<bool> selectedDays, // [Sun, Mon, Tue, Wed, Thu, Fri, Sat]
-  ) {
-    int count = 0;
-    DateTime current = startDate;
-
-    while (!current.isAfter(endDate)) {
-      int weekdayIndex = current.weekday % 7;
-      // Dart: Mon=1..Sun=7, so %7 shifts Sun to 0
-      if (selectedDays[weekdayIndex]) {
-        count++;
-      }
-      current = current.add(const Duration(days: 1));
-    }
-
-    return count;
-  }
-
-  //CRUD Fucntion for editing tasks through this display
-  //Tasks can be edited to the system through other features and will appear in the Calendar
-
   Future<void> _editTask(Task task) async {
     final user = Provider.of<UserProvider>(context, listen: false).user;
     if (user == null) return;
-    // Refresh task from backend so we always use latest recurrence
+
+    // Refresh task from backend
     try {
       final freshResponse = await ApiService.getTaskByIdV2(task.id);
       if (freshResponse.statusCode == 200) {
-        final freshTask = Task.fromJson(jsonDecode(freshResponse.body));
-        task = freshTask; // replace with up-to-date task
-      } else {
-        print("⚠️ Failed to refresh task ${task.id}, using stale data");
+        task = Task.fromJson(jsonDecode(freshResponse.body));
       }
     } catch (e) {
-      print("⚠️ Error refreshing task ${task.id}: $e");
-    }
-    // Controllers
-    final titleController = TextEditingController(text: task.name);
-    final descriptionController = TextEditingController(text: task.description);
-    TimeOfDay? selectedTime = task.timeOfDay;
-    int? selectedPatientId = task.userId;
-
-    int? recDayOfMonth;
-
-    // ----- Prefill recurrence -----
-    // Is it recurring?
-    bool isRecurringLocal =
-        (task.frequency != null && task.frequency!.isNotEmpty) ||
-        ((task.daysOfWeek?.any((e) => e)) ?? false) ||
-        (task.taskType != null && task.taskType!.isNotEmpty);
-
-    // Determine recurrence type to show
-    String? recurrenceTypeLocal;
-    if (task.daysOfWeek != null && task.daysOfWeek!.any((e) => e)) {
-      recurrenceTypeLocal = 'Weekly';
-    } else if (task.frequency != null && task.frequency!.isNotEmpty) {
-      switch (task.frequency!.toLowerCase()) {
-        case 'daily':
-          recurrenceTypeLocal = 'Daily';
-          break;
-        case 'weekly':
-          recurrenceTypeLocal = 'Weekly';
-          break;
-        case 'monthly':
-          recurrenceTypeLocal = 'Monthly';
-          break;
-        case 'yearly':
-          recurrenceTypeLocal = 'Yearly';
-          break;
-        default:
-          recurrenceTypeLocal = null;
-      }
-    } else if (task.taskType != null) {
-      final tt = task.taskType!.toLowerCase();
-      if (tt == 'dayofweek') recurrenceTypeLocal = 'Weekly';
-      if (tt == 'frequency')
-        recurrenceTypeLocal = recurrenceTypeLocal ?? 'Daily';
+      debugPrint("⚠️ Error refreshing task ${task.id}: $e");
     }
 
-    // If monthly, pre-fill the day of month from the task.date
-    if (recurrenceTypeLocal == 'Monthly') {
-      recDayOfMonth = task.date.day;
-    }
-
-    List<bool>? daysOfWeekLocal = task.daysOfWeek;
-    int? intervalLocal = task.interval;
-    int? countLocal = task.count;
-    DateTime? startDateLocal = task.date;
-    DateTime?
-    endDateLocal; // not persisted in v2 – only used for UI math if you want
-    // ----- Caregiver: fetch patients for dropdown -----
+    // Preload patients if caregiver
     List<Map<String, dynamic>> patients = [];
     if (user.isCaregiver) {
       final response = await ApiService.getCaregiverPatients(user.id);
@@ -920,324 +643,50 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
       }
     }
 
-    if (!mounted) return;
-
-    if (task.count != null && task.frequency != null && task.count! > 0) {
-      switch (task.frequency!.toLowerCase()) {
-        case "daily":
-          endDateLocal = task.date.add(
-            Duration(days: (task.count! - 1) * (task.interval ?? 1)),
-          );
-          break;
-        case "weekly":
-          endDateLocal = task.date.add(Duration(days: (task.count! - 1) * 7));
-          break;
-        case "monthly":
-          endDateLocal = DateTime(
-            task.date.year,
-            task.date.month + (task.count ?? 1) - 1,
-            task.date.day,
-          );
-          break;
-        case "yearly":
-          endDateLocal = DateTime(
-            task.date.year + (task.count ?? 1) - 1,
-            task.date.month,
-            task.date.day,
-          );
-          break;
-      }
-    }
-
-    final confirmed = await showDialog<bool>(
+    // Show edit form
+    final editedTask = await showDialog<Task>(
       context: context,
-      builder: (context) {
-        return StatefulBuilder(
-          builder: (context, setInnerState) => AlertDialog(
-            title: const Text("Edit Task"),
-            content: SingleChildScrollView(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  // Title
-                  TextField(
-                    controller: titleController,
-                    decoration: const InputDecoration(
-                      labelText: "Task Title",
-                      border: OutlineInputBorder(),
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-
-                  // Description
-                  TextField(
-                    controller: descriptionController,
-                    maxLines: 3,
-                    decoration: const InputDecoration(
-                      labelText: "Description",
-                      border: OutlineInputBorder(),
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-
-                  // Time picker
-                  Row(
-                    children: [
-                      const Text("Time: "),
-                      Text(
-                        selectedTime != null
-                            ? "${selectedTime!.hour.toString().padLeft(2, '0')}:${selectedTime!.minute.toString().padLeft(2, '0')}"
-                            : "Not set",
-                      ),
-                      const Spacer(),
-                      ElevatedButton(
-                        onPressed: () async {
-                          final picked = await showTimePicker(
-                            context: context,
-                            initialTime: selectedTime ?? TimeOfDay.now(),
-                          );
-                          if (picked != null) {
-                            setInnerState(() => selectedTime = picked);
-                          }
-                        },
-                        child: const Text("Pick Time"),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 12),
-
-                  // Caregiver assignment dropdown
-                  if (user.isPatient)
-                    Text("Assigned to: ${user.name}")
-                  else if (user.isCaregiver)
-                    DropdownButtonFormField<int>(
-                      decoration: const InputDecoration(
-                        labelText: "Assign to Patient",
-                        border: OutlineInputBorder(),
-                      ),
-                      value: selectedPatientId,
-                      items: patients.map((p) {
-                        return DropdownMenuItem<int>(
-                          value: p['patient']?['id'],
-                          child: Text(
-                            "${p['patient']?['firstName']} ${p['patient']?['lastName']}",
-                          ),
-                        );
-                      }).toList(),
-                      onChanged: (val) {
-                        setInnerState(() => selectedPatientId = val);
-                      },
-                    ),
-
-                  const SizedBox(height: 16),
-
-                  // Recurrence (reused component)
-                  RecurrenceForm(
-                    initialIsRecurring: isRecurringLocal,
-                    initialRecurrenceType: recurrenceTypeLocal,
-                    initialDaysOfWeek: daysOfWeekLocal,
-                    initialInterval: intervalLocal,
-                    initialCount: countLocal,
-                    initialStartDate: startDateLocal,
-                    initialEndDate: endDateLocal,
-                    initialDayOfMonth: recDayOfMonth,
-                    onChanged:
-                        ({
-                          bool? isRecurring,
-                          String? recurrenceType,
-                          List<bool>? daysOfWeek,
-                          int? interval,
-                          int? count,
-                          DateTime? startDate,
-                          DateTime? endDate,
-                          int? dayOfMonth,
-                        }) {
-                          setInnerState(() {
-                            // If recurrence type is set, force isRecurring = true
-                            if (recurrenceType != null &&
-                                recurrenceType.isNotEmpty) {
-                              isRecurringLocal = true;
-                            } else {
-                              isRecurringLocal = isRecurring ?? false;
-                            }
-                            recurrenceTypeLocal = recurrenceType;
-                            daysOfWeekLocal = daysOfWeek;
-                            intervalLocal = interval;
-                            countLocal = count;
-                            startDateLocal = startDate;
-                            endDateLocal = endDate;
-                            recDayOfMonth = dayOfMonth;
-                          });
-                        },
-                  ),
-                ],
-              ),
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(context, false),
-                child: const Text("Cancel"),
-              ),
-              ElevatedButton(
-                onPressed:
-                    (isRecurringLocal &&
-                        (recurrenceTypeLocal == null ||
-                            recurrenceTypeLocal!.isEmpty))
-                    ? null // disable if invalid
-                    : () {
-                        if (user.isCaregiver && selectedPatientId == null) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text("Please select a patient"),
-                            ),
-                          );
-                          return;
-                        }
-                        Navigator.pop(context, true);
-                      },
-                child: const Text("Save"),
-              ),
-            ],
-          ),
-        );
-      },
+      builder: (_) => TaskFormDialog(
+        initialTask: task,
+        isCaregiver: user.isCaregiver,
+        patients: patients,
+        defaultPatientId: user.isPatient ? user.id : task.userId,
+      ),
     );
 
-    if (confirmed != true) return;
+    if (editedTask == null) return;
 
-    // Final patientId logic
-    final patientId = user.isPatient ? user.id : selectedPatientId!;
-
-    // Normalize recurrence for payload
-    String? frequencyToSend;
-    String? taskTypeToSend;
-    List<bool>? daysToSend = daysOfWeekLocal;
-    int? intervalToSend = intervalLocal;
-    int? countToSend = countLocal;
-
-    if (isRecurringLocal && (recurrenceTypeLocal != null)) {
-      switch (recurrenceTypeLocal) {
-        case 'Daily':
-          frequencyToSend = 'daily';
-          intervalToSend = intervalToSend ?? 1; // default
-          taskTypeToSend = 'frequency';
-          break;
-        case 'Weekly':
-          frequencyToSend = 'weekly';
-          intervalToSend = intervalToSend ?? 7; // your chosen convention
-          taskTypeToSend = (daysToSend != null && daysToSend.any((e) => e))
-              ? 'dayOfWeek'
-              : 'frequency';
-          break;
-        case 'Monthly':
-          frequencyToSend = 'monthly';
-          intervalToSend = intervalToSend ?? 1;
-          taskTypeToSend = 'frequency';
-          break;
-        case 'Yearly':
-          frequencyToSend = 'yearly';
-          intervalToSend = intervalToSend ?? 365;
-          taskTypeToSend = 'frequency';
-          break;
-      }
-    } else {
-      frequencyToSend = null;
-      intervalToSend = null;
-      countToSend = null;
-      daysToSend = null;
-      taskTypeToSend = 'task';
-    }
-
-    // Override date if monthly recurrence has a chosen day
-    DateTime effectiveDate = startDateLocal ?? task.date;
-
-    if (recurrenceTypeLocal?.toLowerCase() == 'monthly' &&
-        recDayOfMonth != null) {
-      final daysInMonth = DateUtils.getDaysInMonth(
-        effectiveDate.year,
-        effectiveDate.month,
-      );
-      final dom = recDayOfMonth!.clamp(1, daysInMonth);
-      effectiveDate = DateTime(effectiveDate.year, effectiveDate.month, dom);
-    }
-
-    // Recompute count if start+end chosen
-    if (startDateLocal != null &&
-        endDateLocal != null &&
-        recurrenceTypeLocal != null) {
-      switch (recurrenceTypeLocal!.toLowerCase()) {
-        case 'daily':
-          countToSend =
-              ((endDateLocal!.difference(startDateLocal!).inDays) ~/
-                  (intervalToSend ?? 1)) +
-              1;
-          break;
-        case 'weekly':
-          countToSend =
-              ((endDateLocal!.difference(startDateLocal!).inDays) ~/ 7) + 1;
-          break;
-        case 'monthly':
-          countToSend =
-              ((endDateLocal!.year - startDateLocal!.year) * 12 +
-                  (endDateLocal!.month - startDateLocal!.month)) +
-              1;
-          break;
-        case 'yearly':
-          countToSend = (endDateLocal!.year - startDateLocal!.year) + 1;
-          break;
-      }
-    }
-    print(
-      "🧭 Final effectiveDate = $effectiveDate "
-      "(start=$startDateLocal, end=$endDateLocal, dom=$recDayOfMonth)",
-    );
-    // Build updated Task (Task.toJson already includes patientId)
-    final updatedTask = Task(
-      id: task.id,
-      name: titleController.text,
-      description: descriptionController.text,
-      date: effectiveDate, // keep same date unless you add a date picker
-      timeOfDay: selectedTime,
-      userId: patientId,
-      isComplete: task.isComplete,
-      notifications: task.notifications,
-      frequency: frequencyToSend,
-      interval: intervalToSend,
-      count: countToSend,
-      daysOfWeek: daysToSend,
-      taskType: taskTypeToSend,
-    );
+    // ✅ Use RecurrenceUtils to normalize recurrence
+    final newTask = RecurrenceUtils.buildTask(baseTask: editedTask);
 
     try {
-      print("🚀 Sending edit payload: ${jsonEncode(updatedTask.toJson())}");
       final response = await ApiService.editTaskV2(
-        task.id,
-        updatedTask.toJson(),
+        newTask.id,
+        newTask.toJson(),
       );
 
       if (response.statusCode == 200) {
         await _loadTasksFromDb();
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text("Task updated successfully")),
+          const SnackBar(content: Text("✅ Task updated successfully")),
         );
       } else {
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text("Failed: ${response.statusCode}")),
+          SnackBar(
+            content: Text("⚠️ Failed to update task: ${response.statusCode}"),
+          ),
         );
       }
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text("Error: $e")));
+      ).showSnackBar(SnackBar(content: Text("❌ Error updating task: $e")));
     }
   }
 
-  //CRUD Fucntion for removing tasks through this display
-  //Tasks can be removed to the system through other features and will appear in the Calendar
   Future<void> _removeTask(Task task) async {
     final confirmed = await showDialog<bool>(
       context: context,
@@ -1264,13 +713,13 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
 
     try {
       final response = await ApiService.deleteTaskV2(task.id);
-      //Removal message sent if good response then make sure the class updates from DB
+
       if (response.statusCode == 200 || response.statusCode == 204) {
         await _loadTasksFromDb();
         if (!mounted) return;
         ScaffoldMessenger.of(
           context,
-        ).showSnackBar(SnackBar(content: Text("Task '${task.name}' removed")));
+        ).showSnackBar(SnackBar(content: Text("Task '${task.name}' deleted")));
       } else {
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
@@ -1285,6 +734,301 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         context,
       ).showSnackBar(SnackBar(content: Text("Error deleting task: $e")));
     }
+  }
+}
+
+// =============================
+// TaskFormDialog.dart
+// =============================
+
+class TaskFormDialog extends StatefulWidget {
+  final Task? initialTask;
+  final bool isCaregiver;
+  final List<Map<String, dynamic>> patients;
+  final int? defaultPatientId;
+
+  const TaskFormDialog({
+    super.key,
+    this.initialTask,
+    required this.isCaregiver,
+    required this.patients,
+    this.defaultPatientId,
+  });
+
+  @override
+  State<TaskFormDialog> createState() => _TaskFormDialogState();
+}
+
+class _TaskFormDialogState extends State<TaskFormDialog> {
+  late TextEditingController titleController;
+  late TextEditingController descriptionController;
+  TimeOfDay? selectedTime;
+  int? selectedPatientId;
+
+  // Recurrence state
+  bool isRecurring = false;
+  String? recurrenceType;
+  List<bool>? daysOfWeek;
+  int? interval;
+  int? count;
+  DateTime? startDate;
+  DateTime? endDate;
+  int? dayOfMonth;
+
+  @override
+  void initState() {
+    super.initState();
+
+    final t = widget.initialTask;
+
+    titleController = TextEditingController(text: t?.name ?? '');
+    descriptionController = TextEditingController(text: t?.description ?? '');
+    selectedTime = t?.timeOfDay;
+    selectedPatientId = widget.defaultPatientId ?? t?.userId;
+
+    // ensure Save button re-checks when text changes
+    titleController.addListener(() => setState(() {}));
+
+    if (t != null) {
+      recurrenceType = _inferRecurrenceTypeFromTask(t);
+      isRecurring = recurrenceType != null;
+      daysOfWeek = t.daysOfWeek;
+      interval = t.interval;
+      count = t.count;
+      startDate = t.date;
+      if (recurrenceType == "Monthly") {
+        dayOfMonth = t.date.day;
+      }
+
+      // compute end date if missing
+      if (count != null &&
+          count! > 0 &&
+          startDate != null &&
+          recurrenceType != null) {
+        final iv = (interval == null || interval! < 1) ? 1 : interval!;
+        switch (recurrenceType!.toLowerCase()) {
+          case "daily":
+            endDate = startDate!.add(Duration(days: (count! - 1) * iv));
+            break;
+          case "weekly":
+            endDate = startDate!.add(Duration(days: (count! - 1) * 7 * iv));
+            break;
+          case "monthly":
+            endDate = DateTime(
+              startDate!.year,
+              startDate!.month + (count! - 1) * iv,
+              startDate!.day,
+            );
+            break;
+          case "yearly":
+            endDate = DateTime(
+              startDate!.year + (count! - 1) * iv,
+              startDate!.month,
+              startDate!.day,
+            );
+            break;
+        }
+      }
+    } else {
+      startDate = DateTime.now();
+    }
+  }
+
+  String? _inferRecurrenceTypeFromTask(Task t) {
+    if (t.daysOfWeek?.any((d) => d) ?? false) return "Weekly";
+    switch (t.frequency?.toLowerCase()) {
+      case "daily":
+        return "Daily";
+      case "weekly":
+        return "Weekly";
+      case "monthly":
+        return "Monthly";
+      case "yearly":
+        return "Yearly";
+      default:
+        return null;
+    }
+  }
+
+  /// validation logic
+  bool get canSave {
+    // Must have a name
+    if (titleController.text.trim().isEmpty) return false;
+
+    if (isRecurring) {
+      // Must have a recurrence type
+      if (recurrenceType == null || recurrenceType!.isEmpty) return false;
+
+      // Weekly: require at least one day
+      if (recurrenceType!.toLowerCase() == "weekly") {
+        if (daysOfWeek == null || !daysOfWeek!.any((d) => d)) {
+          return false;
+        }
+      }
+
+      // Must have an end condition (endDate or count)
+      if ((endDate == null || endDate!.isBefore(startDate ?? DateTime.now())) &&
+          (count == null || count! <= 0)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.initialTask == null ? "Add Task" : "Edit Task"),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Title
+            TextField(
+              controller: titleController,
+              decoration: const InputDecoration(
+                labelText: "Task Title",
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+
+            // Description
+            TextField(
+              controller: descriptionController,
+              maxLines: 3,
+              decoration: const InputDecoration(
+                labelText: "Description",
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+
+            // Time picker
+            Row(
+              children: [
+                const Text("Time: "),
+                Text(
+                  selectedTime != null
+                      ? "${selectedTime!.hour.toString().padLeft(2, '0')}:${selectedTime!.minute.toString().padLeft(2, '0')}"
+                      : "Not set",
+                ),
+                const Spacer(),
+                ElevatedButton(
+                  onPressed: () async {
+                    final picked = await showTimePicker(
+                      context: context,
+                      initialTime: selectedTime ?? TimeOfDay.now(),
+                    );
+                    if (picked != null) setState(() => selectedTime = picked);
+                  },
+                  child: const Text("Pick Time"),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+
+            // Caregiver dropdown
+            if (widget.isCaregiver)
+              DropdownButtonFormField<int>(
+                decoration: const InputDecoration(
+                  labelText: "Assign to Patient",
+                  border: OutlineInputBorder(),
+                ),
+                value: selectedPatientId,
+                items: widget.patients.map((p) {
+                  return DropdownMenuItem<int>(
+                    value: p['patient']?['id'],
+                    child: Text(
+                      "${p['patient']?['firstName']} ${p['patient']?['lastName']}",
+                    ),
+                  );
+                }).toList(),
+                onChanged: (val) => setState(() => selectedPatientId = val),
+              ),
+
+            const SizedBox(height: 16),
+
+            // Recurrence form
+            RecurrenceForm(
+              initialIsRecurring: isRecurring,
+              initialRecurrenceType: recurrenceType,
+              initialDaysOfWeek: daysOfWeek,
+              initialInterval: interval,
+              initialCount: count,
+              initialStartDate: startDate,
+              initialEndDate: endDate,
+              initialDayOfMonth: dayOfMonth,
+              onChanged:
+                  ({
+                    bool? isRecurring,
+                    String? recurrenceType,
+                    List<bool>? daysOfWeek,
+                    int? interval,
+                    int? count,
+                    DateTime? startDate,
+                    DateTime? endDate,
+                    int? dayOfMonth,
+                  }) {
+                    setState(() {
+                      this.isRecurring = isRecurring ?? false;
+                      this.recurrenceType = recurrenceType;
+                      this.daysOfWeek = daysOfWeek;
+                      this.interval = interval;
+                      this.count = count;
+                      this.startDate = startDate ?? this.startDate;
+                      this.endDate = endDate;
+                      this.dayOfMonth = dayOfMonth;
+                    });
+                  },
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, null),
+          child: const Text("Cancel"),
+        ),
+        ElevatedButton(
+          onPressed: canSave
+              ? () {
+                  final rawTask = Task(
+                    id: widget.initialTask?.id ?? -1,
+                    name: titleController.text,
+                    description: descriptionController.text,
+                    date: startDate ?? DateTime.now(),
+                    timeOfDay: selectedTime,
+                    userId: selectedPatientId,
+                    isComplete: widget.initialTask?.isComplete ?? false,
+                    notifications: widget.initialTask?.notifications,
+                    frequency: recurrenceType,
+                    interval: interval,
+                    count: count,
+                    daysOfWeek: daysOfWeek,
+                    taskType: widget.initialTask?.taskType,
+                  );
+
+                  final finalTask = RecurrenceUtils.buildTask(
+                    baseTask: rawTask,
+                    isRecurring: isRecurring,
+                    recurrenceType: recurrenceType,
+                    daysOfWeek: daysOfWeek,
+                    interval: interval,
+                    count: count,
+                    startDate: rawTask.date,
+                    endDate: endDate,
+                    dayOfMonth: dayOfMonth,
+                  );
+
+                  Navigator.pop(context, finalTask);
+                }
+              : null, // ✅ disabled if invalid
+          child: const Text("Save"),
+        ),
+      ],
+    );
   }
 }
 
@@ -1345,13 +1089,26 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
     super.initState();
     isRecurring = widget.initialIsRecurring;
     recurrenceType = widget.initialRecurrenceType;
-    daysOfWeek = widget.initialDaysOfWeek;
+    daysOfWeek = widget.initialDaysOfWeek ?? List.filled(7, false);
     interval = widget.initialInterval;
     count = widget.initialCount;
     startDate = widget.initialStartDate;
     endDate = widget.initialEndDate;
     dayOfMonth = widget.initialDayOfMonth;
   }
+
+  // --- validation flags for inline error messages ---
+  bool get isMissingType =>
+      isRecurring && (recurrenceType == null || recurrenceType!.isEmpty);
+
+  bool get isWeeklyInvalid =>
+      recurrenceType == "Weekly" && !(daysOfWeek?.any((d) => d) ?? false);
+
+  bool get isMissingEndCondition =>
+      isRecurring &&
+      ((endDate == null ||
+              (startDate != null && endDate!.isBefore(startDate!))) &&
+          (count == null || count! <= 0));
 
   @override
   Widget build(BuildContext context) {
@@ -1363,7 +1120,6 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
           value: isRecurring,
           onChanged: (val) {
             setState(() => isRecurring = val ?? false);
-
             widget.onChanged(
               isRecurring: isRecurring,
               recurrenceType: recurrenceType,
@@ -1376,11 +1132,9 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
             );
           },
         ),
-
         if (isRecurring) ...[
           const SizedBox(height: 8),
-
-          // Recurrence Type Dropdown
+          // Recurrence type dropdown
           DropdownButtonFormField<String>(
             decoration: const InputDecoration(labelText: "Recurrence Type"),
             value: recurrenceType,
@@ -1392,7 +1146,6 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
             ].map((t) => DropdownMenuItem(value: t, child: Text(t))).toList(),
             onChanged: (val) {
               setState(() => recurrenceType = val);
-
               widget.onChanged(
                 isRecurring: isRecurring,
                 recurrenceType: recurrenceType,
@@ -1405,33 +1158,28 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
               );
             },
           ),
-          // Inline warning message
-          if (isRecurring &&
-              (recurrenceType == null || recurrenceType!.isEmpty))
+          if (isMissingType)
             const Padding(
-              padding: EdgeInsets.only(top: 8.0, left: 4.0),
+              padding: EdgeInsets.only(top: 4.0),
               child: Text(
                 "⚠ Please select a recurrence type",
                 style: TextStyle(color: Colors.red, fontSize: 12),
               ),
             ),
-          const SizedBox(height: 16),
 
-          // Weekly → day-of-week picker
+          // Weekly days-of-week picker
           if (recurrenceType == "Weekly") ...[
+            const SizedBox(height: 12),
             const Text("Select Days of Week"),
             Wrap(
               spacing: 8,
-              children: List.generate(7, (index) {
+              children: List.generate(7, (i) {
                 const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
                 return FilterChip(
-                  label: Text(days[index]),
-                  selected: (daysOfWeek ?? List.filled(7, false))[index],
+                  label: Text(days[i]),
+                  selected: daysOfWeek?[i] ?? false,
                   onSelected: (selected) {
-                    setState(() {
-                      daysOfWeek ??= List.filled(7, false);
-                      daysOfWeek![index] = selected;
-                    });
+                    setState(() => daysOfWeek?[i] = selected);
                     widget.onChanged(
                       isRecurring: isRecurring,
                       recurrenceType: recurrenceType,
@@ -1446,11 +1194,19 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
                 );
               }),
             ),
+            if (isWeeklyInvalid)
+              const Padding(
+                padding: EdgeInsets.only(top: 4.0),
+                child: Text(
+                  "⚠ Please select at least one day of the week",
+                  style: TextStyle(color: Colors.red, fontSize: 12),
+                ),
+              ),
           ],
 
           // Monthly → day-of-month picker
           if (recurrenceType == "Monthly") ...[
-            const SizedBox(height: 16),
+            const SizedBox(height: 12),
             Row(
               children: [
                 const Text("Day of Month:"),
@@ -1483,18 +1239,16 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
               ],
             ),
           ],
-          // Start Date Picker
+
+          const SizedBox(height: 16),
+
+          // Start date picker
           Row(
             children: [
               Text(
                 startDate != null
-                    ? (recurrenceType == "Yearly"
-                          // If yearly, clarify this is the day/month
-                          ? "Occurs: ${startDate!.month}/${startDate!.day}"
-                          : "Starts: ${startDate!.toLocal().toString().split(' ')[0]}")
-                    : (recurrenceType == "Yearly"
-                          ? "No yearly day/month set"
-                          : "No start date set"),
+                    ? "Starts: ${startDate!.toLocal().toString().split(' ')[0]}"
+                    : "No start date set",
               ),
               const Spacer(),
               TextButton(
@@ -1502,7 +1256,7 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
                   final picked = await showDatePicker(
                     context: context,
                     initialDate: startDate ?? DateTime.now(),
-                    firstDate: DateTime(2000), // allow past
+                    firstDate: DateTime(2000),
                     lastDate: DateTime(DateTime.now().year + 5),
                   );
                   if (picked != null) {
@@ -1513,100 +1267,63 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
                       daysOfWeek: daysOfWeek,
                       interval: interval,
                       count: count,
+                      startDate: startDate,
                       endDate: endDate,
                       dayOfMonth: dayOfMonth,
-                      startDate: startDate,
                     );
                   }
                 },
-                child: Text(
-                  recurrenceType == "Yearly"
-                      ? "Pick Day/Month"
-                      : "Pick Start Date",
-                ),
+                child: const Text("Pick Start Date"),
               ),
             ],
           ),
 
-          // End Date OR End Year Picker
-          const SizedBox(height: 16),
-          if (recurrenceType == "Yearly") ...[
-            Row(
-              children: [
-                Text(
-                  endDate != null
-                      ? "Ends in Year: ${endDate!.year}"
-                      : "No end year set",
-                ),
-                const SizedBox(width: 12),
-                DropdownButton<int>(
-                  hint: const Text("Select End Year"),
-                  value: endDate?.year,
-                  items:
-                      List.generate(
-                        10, // next 10 years
-                        (i) => DateTime.now().year + i,
-                      ).map((year) {
-                        return DropdownMenuItem(
-                          value: year,
-                          child: Text(year.toString()),
-                        );
-                      }).toList(),
-                  onChanged: (val) {
-                    if (val != null) {
-                      // Store as Jan 1 of that year (you only care about year)
-                      setState(() => endDate = DateTime(val, 1, 1));
-                      widget.onChanged(
-                        isRecurring: isRecurring,
-                        recurrenceType: recurrenceType,
-                        daysOfWeek: daysOfWeek,
-                        interval: interval,
-                        count: count,
-                        endDate: endDate,
-                        startDate: startDate,
-                        dayOfMonth: dayOfMonth,
-                      );
-                    }
-                  },
-                ),
-              ],
-            ),
-          ] else ...[
-            Row(
-              children: [
-                Text(
-                  endDate != null
-                      ? "Ends: ${endDate!.toLocal().toString().split(' ')[0]}"
-                      : "No end date set",
-                ),
-                const Spacer(),
-                TextButton(
-                  onPressed: () async {
-                    final picked = await showDatePicker(
-                      context: context,
-                      initialDate: endDate ?? DateTime.now(),
-                      firstDate: DateTime.now(),
-                      lastDate: DateTime(DateTime.now().year + 5),
+          const SizedBox(height: 12),
+
+          // End date picker
+          Row(
+            children: [
+              Text(
+                endDate != null
+                    ? "Ends: ${endDate!.toLocal().toString().split(' ')[0]}"
+                    : "No end date set",
+              ),
+              const Spacer(),
+              TextButton(
+                onPressed: () async {
+                  final picked = await showDatePicker(
+                    context: context,
+                    initialDate: endDate ?? DateTime.now(),
+                    firstDate: DateTime.now(),
+                    lastDate: DateTime(DateTime.now().year + 5),
+                  );
+                  if (picked != null) {
+                    setState(() => endDate = picked);
+                    widget.onChanged(
+                      isRecurring: isRecurring,
+                      recurrenceType: recurrenceType,
+                      daysOfWeek: daysOfWeek,
+                      interval: interval,
+                      count: count,
+                      startDate: startDate,
+                      endDate: endDate,
+                      dayOfMonth: dayOfMonth,
                     );
-                    if (picked != null) {
-                      setState(() => endDate = picked);
-                      widget.onChanged(
-                        isRecurring: isRecurring,
-                        recurrenceType: recurrenceType,
-                        daysOfWeek: daysOfWeek,
-                        interval: interval,
-                        count: count,
-                        endDate: endDate,
-                        startDate: startDate,
-                        dayOfMonth: dayOfMonth,
-                      );
-                    }
-                  },
-                  child: const Text("Pick End Date"),
-                ),
-              ],
+                  }
+                },
+                child: const Text("Pick End Date"),
+              ),
+            ],
+          ),
+
+          if (isMissingEndCondition)
+            const Padding(
+              padding: EdgeInsets.only(top: 4.0),
+              child: Text(
+                "⚠ Please provide an end date of the series",
+                style: TextStyle(color: Colors.red, fontSize: 12),
+              ),
             ),
-          ],
         ],
       ],
     );

--- a/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
@@ -59,11 +59,14 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
   }
 
   //Function for making sure the Calendar displayed has updated DB information
+
   Future<void> _loadTasksFromDb() async {
     setState(() {
       isLoading = true;
       error = null;
     });
+
+    log("🛰️ Starting DB Query");
 
     try {
       final user = Provider.of<UserProvider>(context, listen: false).user;
@@ -74,83 +77,107 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         });
         return;
       }
-      List<Task> allTasks = [];
-      //Branching point if patient then you see your own event,
-      //if caregiver then you see your patients events
+
+      final List<Task> allTasks = [];
+      if (user.isCaregiver) {
+        // refresh patient name map each load
+        patientNames.clear();
+      }
+
+      // Helper to normalize a raw map before Task.fromJson
+      Map<String, dynamic> normalizeTaskMap(Map<String, dynamic> map) {
+        // Normalize date string and keep it ISO-like
+        if (map['date'] != null && map['date'] is String) {
+          final d = map['date'] as String;
+          // ensure ISO separator
+          if (!d.contains('T')) {
+            map['date'] = d.replaceFirst(' ', 'T');
+          }
+        }
+
+        // Normalize daysOfWeek to List<bool>
+        final dow = map['daysOfWeek'];
+        if (dow == null || dow == "null") {
+          map['daysOfWeek'] = [];
+        } else if (dow is String) {
+          try {
+            map['daysOfWeek'] = List<bool>.from(jsonDecode(dow));
+          } catch (_) {
+            map['daysOfWeek'] = [];
+          }
+        }
+
+        // Accept both 'isComplete' and 'completed'
+        if (map['isComplete'] == null && map['completed'] != null) {
+          map['isComplete'] = map['completed'];
+        }
+
+        return map;
+      }
+
       // --- PATIENT FLOW ---
       if (user.isPatient) {
+        print("🛰️ In the patient flow");
         final response = await ApiService.getPatientTasksV2(
           user.id,
         ).timeout(const Duration(seconds: 30));
         if (response.statusCode == 200) {
           final List data = json.decode(response.body);
-          for (var raw in data) {
-            final map = Map<String, dynamic>.from(raw);
-
-            if (map['date'] != null && map['date'] is String) {
-              String d = map['date'];
-              if (!d.contains("T")) {
-                map['date'] = d.replaceFirst(" ", "T");
-              }
-            }
-
-            if (map['daysOfWeek'] == null || map['daysOfWeek'] == "null") {
-              map['daysOfWeek'] = [];
-            }
-
+          for (final raw in data) {
+            final map = normalizeTaskMap(Map<String, dynamic>.from(raw));
             try {
-              final task = Task.fromJson(map);
-              allTasks.add(task);
+              final baseTask = Task.fromJson(map);
+              // Ensure local time normalization
+              baseTask.date = baseTask.date.toLocal();
+              final expandedOccurrences = baseTask.expandOccurrences();
+              print(
+                "📅 Expanded ${baseTask.name}: ${expandedOccurrences.length} occurrences",
+              );
+              allTasks.addAll(expandedOccurrences);
             } catch (e) {
-              log("Error: $e");
+              log("Error parsing task: $e");
             }
           }
         }
       }
       // --- CAREGIVER FLOW ---
       else if (user.isCaregiver) {
+        print("🛰️ In care giverflow");
         final patientsResponse = await ApiService.getCaregiverPatients(user.id);
         if (patientsResponse.statusCode == 200) {
           final List patients = json.decode(patientsResponse.body);
-          //Need name information for assignements
-          for (var patient in patients) {
-            final patientId = patient['patient']?['id'];
+
+          for (final patient in patients) {
+            final pid = patient['patient']?['id'];
             final firstName = patient['patient']?['firstName'] ?? '';
             final lastName = patient['patient']?['lastName'] ?? '';
 
-            if (patientId != null) {
-              // Save the patient name for later lookup
-              patientNames[patientId] = "$firstName $lastName";
+            if (pid != null) {
+              patientNames[pid] = "$firstName $lastName".trim();
             }
-
-            //Skipping patient with null id
-            if (patientId == null) {
-              continue;
-            }
+            if (pid == null) continue;
 
             final taskResponse = await ApiService.getPatientTasksV2(
-              patientId,
+              pid,
             ).timeout(const Duration(seconds: 30));
             if (taskResponse.statusCode == 200) {
+              print("🛰️ Response body: ${taskResponse.body}");
               final List data = json.decode(taskResponse.body);
-              for (var raw in data) {
-                final map = Map<String, dynamic>.from(raw);
-
-                if (map['date'] != null && map['date'] is String) {
-                  String d = map['date'];
-                  if (!d.contains("T")) {
-                    map['date'] = d.replaceFirst(" ", "T");
-                  }
-                }
-                if (map['daysOfWeek'] == null || map['daysOfWeek'] == "null") {
-                  map['daysOfWeek'] = [];
-                }
-
+              for (final raw in data) {
+                final map = normalizeTaskMap(Map<String, dynamic>.from(raw));
                 try {
                   final task = Task.fromJson(map);
-                  allTasks.add(task);
+                  task.date = task.date.toLocal(); // UTC → local
+                  final expanded = task.expandOccurrences();
+                  print(
+                    "📅 Expanded ${task.name}: ${expanded.length} occurrences",
+                  );
+                  for (var occ in expanded) {
+                    print("   -> ${occ.date}");
+                  }
+                  allTasks.addAll(task.expandOccurrences());
                 } catch (e) {
-                  log("Error: $e");
+                  log("Error parsing caregiver task: $e");
                 }
               }
             }
@@ -164,20 +191,23 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         hashCode: (date) => date.day * 1000000 + date.month * 10000 + date.year,
       );
 
-      for (var task in allTasks) {
-        final dateKey = DateTime(
-          task.date.year,
-          task.date.month,
-          task.date.day,
-        );
-        grouped.putIfAbsent(dateKey, () => []);
-        grouped[dateKey]!.add(task);
+      for (final task in allTasks) {
+        final key = DateTime(task.date.year, task.date.month, task.date.day);
+        print("📌 Grouping task ${task.name} on $key");
+        grouped.putIfAbsent(key, () => []).add(task);
       }
+      print("📊 Final grouped keys:");
+      grouped.forEach((k, v) {
+        print("   $k -> ${v.length} tasks");
+      });
+
+      if (!mounted) return;
       setState(() {
         tasks = grouped;
         isLoading = false;
       });
     } catch (e) {
+      if (!mounted) return;
       setState(() {
         error = "Error: $e";
         isLoading = false;
@@ -235,7 +265,14 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
                 lastDay: DateTime.utc(2030, 12, 31),
                 focusedDay: _focusedDay,
                 selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
-                eventLoader: (day) => tasks[day] ?? [],
+                eventLoader: (day) {
+                  final key = DateTime(
+                    day.year,
+                    day.month,
+                    day.day,
+                  ); // normalize to midnight
+                  return tasks[key] ?? [];
+                },
                 onDaySelected: (selectedDay, focusedDay) {
                   setState(() {
                     _selectedDay = selectedDay;
@@ -398,6 +435,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
 
   //CRUD Fucntion for adding tasks through this display
   //Tasks can be added to the system through other features and will appear in the Calendar
+
   Future<void> _addTask() async {
     final user = Provider.of<UserProvider>(context, listen: false).user;
     if (user == null) return;
@@ -405,7 +443,25 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     final titleController = TextEditingController();
     final descriptionController = TextEditingController();
     TimeOfDay? selectedTime;
-    int? selectedPatientId;
+
+    // Default to selected calendar day
+    final selectedDate = DateTime(
+      (_selectedDay ?? _focusedDay).year,
+      (_selectedDay ?? _focusedDay).month,
+      (_selectedDay ?? _focusedDay).day,
+    );
+
+    int? selectedPatientId = user.isPatient ? user.id : null;
+
+    // Local holders for recurrence
+    bool recIsRecurring = false;
+    String? recType;
+    List<bool>? recDaysOfWeek;
+    DateTime? recStartDate;
+    DateTime? recEndDate;
+    int? recInterval;
+    int? recCount;
+    int? recDayOfMonth;
 
     // If caregiver, fetch patients for dropdown
     List<Map<String, dynamic>> patients = [];
@@ -415,216 +471,37 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         patients = List<Map<String, dynamic>>.from(jsonDecode(response.body));
       }
     }
-    if (!mounted) return;
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) {
-        return StatefulBuilder(
-          builder: (context, setState) => Dialog(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: SingleChildScrollView(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    TextField(
-                      controller: titleController,
-                      decoration: const InputDecoration(
-                        labelText: "Task Title",
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    TextField(
-                      controller: descriptionController,
-                      decoration: const InputDecoration(
-                        labelText: "Description",
-                      ),
-                    ),
-                    const SizedBox(height: 8),
 
-                    // Time picker
-                    Row(
-                      children: [
-                        Text(
-                          selectedTime != null
-                              ? "Time: ${selectedTime!.format(context)}"
-                              : "Time: Not set",
-                        ),
-                        const Spacer(),
-                        TextButton(
-                          onPressed: () async {
-                            final picked = await showTimePicker(
-                              context: context,
-                              initialTime: TimeOfDay.now(),
-                            );
-                            if (picked != null) {
-                              setState(() {
-                                selectedTime = picked;
-                              });
-                            }
-                          },
-                          child: const Text("Pick Time"),
-                        ),
-                      ],
-                    ),
-
-                    const SizedBox(height: 12),
-
-                    // Caregiver: show dropdown
-                    if (user.isCaregiver)
-                      DropdownButtonFormField<int>(
-                        decoration: const InputDecoration(
-                          labelText: "Assign to Patient",
-                          border: OutlineInputBorder(),
-                        ),
-                        items: patients.map((p) {
-                          final patient = p['patient'];
-                          return DropdownMenuItem<int>(
-                            value: patient['id'],
-                            child: Text(
-                              "${patient['firstName']} ${patient['lastName']}",
-                            ),
-                          );
-                        }).toList(),
-                        onChanged: (val) {
-                          setState(() {
-                            selectedPatientId = val;
-                          });
-                        },
-                      )
-                    else
-                      Text("Assigned to: ${user.name}"),
-                    const SizedBox(height: 12),
-
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: [
-                        TextButton(
-                          onPressed: () => Navigator.pop(context, false),
-                          child: const Text("Cancel"),
-                        ),
-                        ElevatedButton(
-                          onPressed: () {
-                            if (user.isCaregiver && selectedPatientId == null) {
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                const SnackBar(
-                                  content: Text("Please select a patient"),
-                                ),
-                              );
-                              return;
-                            }
-                            Navigator.pop(context, true);
-                          },
-                          child: const Text("Save"),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        );
-      },
-    );
-
-    if (confirmed != true) return;
-
-    //Pick correct patientId
-    final patientId = user.isPatient ? user.id : selectedPatientId!;
-
-    final newTaskJson = {
-      'id': -1,
-      'name': titleController.text,
-      'description': descriptionController.text,
-      'date': (_selectedDay ?? DateTime.now()).toIso8601String(),
-      'timeOfDay': selectedTime != null
-          ? '${selectedTime!.hour.toString().padLeft(2, '0')}:${selectedTime!.minute.toString().padLeft(2, '0')}'
-          : null,
-      'userId': patientId,
-    };
-
-    try {
-      final response = await ApiService.createTask(
-        patientId,
-        jsonEncode(newTaskJson),
-      );
-      if (response.statusCode == 200 || response.statusCode == 201) {
-        await _loadTasksFromDb();
-        if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text("Task added successfully")),
-        );
-      } else {
-        if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text("Failed to add task: ${response.statusCode}")),
-        );
-      }
-    } catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text("Error adding task: $e")));
-    }
-  }
-
-  //CRUD Fucntion for editing tasks through this display
-  //Tasks can be edited to the system through other features and will appear in the Calendar
-  Future<void> _editTask(Task task) async {
-    final user = Provider.of<UserProvider>(context, listen: false).user;
-    if (user == null) return;
-
-    final titleController = TextEditingController(text: task.name);
-    final descriptionController = TextEditingController(text: task.description);
-    TimeOfDay? selectedTime = task.timeOfDay;
-
-    int? selectedPatientId = task.userId;
-
-    // If caregiver, fetch their patients for dropdown
-    List<Map<String, dynamic>> patients = [];
-    if (user.isCaregiver) {
-      final response = await ApiService.getCaregiverPatients(user.id);
-      if (response.statusCode == 200) {
-        patients = List<Map<String, dynamic>>.from(jsonDecode(response.body));
-      }
-    }
     if (!mounted) return;
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) {
         return StatefulBuilder(
           builder: (context, setState) => AlertDialog(
-            title: const Text("Edit Task"),
+            title: const Text("Add Task"),
             content: SingleChildScrollView(
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 12.0),
-                    child: TextField(
-                      controller: titleController,
-                      decoration: const InputDecoration(
-                        labelText: "Task Title",
-                        border: OutlineInputBorder(),
-                      ),
+                  // Title
+                  TextField(
+                    controller: titleController,
+                    decoration: const InputDecoration(
+                      labelText: "Task Title",
+                      border: OutlineInputBorder(),
                     ),
                   ),
+                  const SizedBox(height: 12),
 
-                  // Description field
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 12.0),
-                    child: TextField(
-                      controller: descriptionController,
-                      maxLines:
-                          3, //Allows multiline so text doesn’t get cramped
-                      decoration: const InputDecoration(
-                        labelText: "Description",
-                        border: OutlineInputBorder(),
-                      ),
+                  // Description
+                  TextField(
+                    controller: descriptionController,
+                    maxLines: 3,
+                    decoration: const InputDecoration(
+                      labelText: "Description",
+                      border: OutlineInputBorder(),
                     ),
                   ),
-
                   const SizedBox(height: 12),
 
                   // Time picker
@@ -644,19 +521,16 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
                             initialTime: selectedTime ?? TimeOfDay.now(),
                           );
                           if (picked != null) {
-                            setState(() {
-                              selectedTime = picked;
-                            });
+                            setState(() => selectedTime = picked);
                           }
                         },
                         child: const Text("Pick Time"),
                       ),
                     ],
                   ),
-
                   const SizedBox(height: 12),
 
-                  // Caregiver can reassign task
+                  // Caregiver assignment dropdown
                   if (user.isPatient)
                     Text("Assigned to: ${user.name}")
                   else if (user.isCaregiver)
@@ -665,7 +539,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
                         labelText: "Assign to Patient",
                         border: OutlineInputBorder(),
                       ),
-                      initialValue: selectedPatientId,
+                      value: selectedPatientId,
                       items: patients.map((p) {
                         return DropdownMenuItem<int>(
                           value: p['patient']?['id'],
@@ -675,11 +549,40 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
                         );
                       }).toList(),
                       onChanged: (val) {
-                        setState(() {
-                          selectedPatientId = val;
-                        });
+                        setState(() => selectedPatientId = val);
                       },
                     ),
+
+                  const SizedBox(height: 16),
+
+                  // Recurrence form
+                  RecurrenceForm(
+                    onChanged:
+                        ({
+                          bool? isRecurring,
+                          String? recurrenceType,
+                          List<bool>? daysOfWeek,
+                          int? interval,
+                          int? count,
+                          DateTime? startDate,
+                          DateTime? endDate,
+                          int? dayOfMonth,
+                        }) {
+                          setState(() {
+                            // update local state for validation
+                            recIsRecurring = isRecurring ?? false;
+                            recType = recurrenceType;
+                          });
+
+                          recType = recurrenceType;
+                          recDaysOfWeek = daysOfWeek;
+                          recInterval = interval;
+                          recCount = count;
+                          recStartDate = startDate;
+                          recEndDate = endDate;
+                          recDayOfMonth = dayOfMonth;
+                        },
+                  ),
                 ],
               ),
             ),
@@ -689,15 +592,20 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
                 child: const Text("Cancel"),
               ),
               ElevatedButton(
-                onPressed: () {
-                  if (user.isCaregiver && selectedPatientId == null) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text("Please select a patient")),
-                    );
-                    return;
-                  }
-                  Navigator.pop(context, true);
-                },
+                onPressed:
+                    (recIsRecurring && (recType == null || recType!.isEmpty))
+                    ? null //disable if recurring but no type
+                    : () {
+                        if (user.isCaregiver && selectedPatientId == null) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text("Please select a patient"),
+                            ),
+                          );
+                          return;
+                        }
+                        Navigator.pop(context, true);
+                      },
                 child: const Text("Save"),
               ),
             ],
@@ -707,32 +615,607 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     );
 
     if (confirmed != true) return;
-    // deciding logic for patient id based on user
+    DateTime effectiveDate = selectedDate;
+    final patientId = user.isPatient ? user.id : selectedPatientId!;
+    // Calculate recurrence fields if recurring
+    if (recIsRecurring && recType != null && recEndDate != null) {
+      switch (recType!.toLowerCase()) {
+        case "daily":
+          recInterval = (recInterval == null || recInterval! < 1)
+              ? 1
+              : recInterval;
+          final DateTime baseStart = recStartDate ?? selectedDate;
+          recCount ??=
+              (recEndDate!.difference(baseStart).inDays ~/ recInterval!) + 1;
+          break;
+        case "weekly":
+          recInterval = (recInterval == null || recInterval! < 1)
+              ? 1
+              : recInterval;
+          if (recDaysOfWeek != null && recDaysOfWeek!.contains(true)) {
+            int totalWeeks =
+                recEndDate!.difference(selectedDate).inDays ~/ 7 + 1;
+            int selectedDays = recDaysOfWeek!.where((d) => d).length;
+            recCount ??= totalWeeks * selectedDays;
+          } else {
+            recCount ??= recEndDate!.difference(selectedDate).inDays ~/ 7 + 1;
+          }
+          break;
+
+        case "monthly":
+          recInterval = (recInterval == null || recInterval! < 1)
+              ? 1
+              : recInterval;
+          int months =
+              (recEndDate!.year - selectedDate.year) * 12 +
+              (recEndDate!.month - selectedDate.month) +
+              1;
+          recCount ??= months;
+          break;
+
+        case "yearly":
+          recInterval = (recInterval == null || recInterval! < 1)
+              ? 1
+              : recInterval;
+          if (recStartDate != null && recEndDate != null) {
+            // Use only the year difference regardless of month/day
+            final startYear = recStartDate!.year;
+            final endYear = recEndDate!.year;
+
+            recCount = (endYear - startYear) + 1;
+
+            // Ensure effectiveDate is set to the correct day/month from startDate
+            effectiveDate = DateTime(
+              startYear,
+              recStartDate!.month,
+              recStartDate!.day,
+            );
+          } else {
+            recCount ??= 5; // fallback default
+          }
+          break;
+      }
+    }
+
+    // Override base date if monthly recurrence specifies a day-of-month
+
+    if (recStartDate != null) {
+      effectiveDate = recStartDate!;
+    }
+
+    if (recType?.toLowerCase() == "monthly" && recEndDate != null) {
+      final daysInMonth = DateUtils.getDaysInMonth(
+        selectedDate.year,
+        selectedDate.month,
+      );
+      final dom = recDayOfMonth!.clamp(1, daysInMonth);
+      effectiveDate = DateTime(selectedDate.year, selectedDate.month, dom);
+    }
+
+    // Normalize recurrence fields
+    String? frequencyToSend;
+    String? taskTypeToSend;
+    int? intervalToSend = recInterval;
+    int? countToSend = recCount;
+
+    if (recIsRecurring && recType != null) {
+      switch (recType!.toLowerCase()) {
+        case "daily":
+          frequencyToSend = "daily";
+          intervalToSend = 1;
+          countToSend = (countToSend == null || countToSend < 1)
+              ? ((recEndDate != null)
+                    ? recEndDate!.difference(selectedDate).inDays + 1
+                    : 30) // default 30
+              : countToSend;
+          taskTypeToSend = "frequency";
+          break;
+
+        case "weekly":
+          frequencyToSend = "weekly";
+          intervalToSend = (intervalToSend == null || intervalToSend < 1)
+              ? 1
+              : intervalToSend;
+          countToSend ??= 4; // default 4 weeks
+          taskTypeToSend =
+              (recDaysOfWeek != null && recDaysOfWeek!.any((e) => e))
+              ? "dayOfWeek"
+              : "frequency";
+          break;
+
+        case "monthly":
+          frequencyToSend = "monthly";
+          intervalToSend = (intervalToSend == null || intervalToSend < 1)
+              ? 1
+              : intervalToSend;
+          countToSend ??= 12;
+          taskTypeToSend = "frequency";
+          break;
+
+        case "yearly":
+          frequencyToSend = "yearly";
+          intervalToSend = (intervalToSend == null || intervalToSend < 1)
+              ? 1
+              : intervalToSend;
+          countToSend = (countToSend == null || countToSend < 1)
+              ? 5
+              : countToSend;
+          taskTypeToSend = "frequency";
+          break;
+      }
+    }
+    // Build new task object
+    final newTask = Task(
+      id: -1,
+      name: titleController.text,
+      description: descriptionController.text,
+      date: effectiveDate,
+      timeOfDay: selectedTime,
+      userId: patientId,
+      isComplete: false,
+      notifications: null,
+      frequency: frequencyToSend,
+      interval: intervalToSend,
+      count: countToSend,
+      daysOfWeek: recDaysOfWeek,
+      taskType: taskTypeToSend,
+    );
+    print(
+      "🧭 Creating task -> freq=$frequencyToSend interval=$intervalToSend count=$countToSend start=$effectiveDate",
+    );
+    try {
+      print("🛰️ Response body:  ${jsonEncode(newTask.toJson())}");
+      final response = await ApiService.createTaskV2(
+        patientId,
+        jsonEncode(newTask.toJson()),
+      );
+
+      if (response.statusCode == 200) {
+        await _loadTasksFromDb();
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text("Task added successfully")),
+        );
+      } else {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text("Failed to add task: ${response.statusCode}")),
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text("Error adding task: $e")));
+    }
+  }
+
+  /// helper function to calculate recurrence count
+  int _calculateCount(
+    String recurrenceType,
+    int interval,
+    DateTime startDate,
+    DateTime endDate, {
+    List<bool>? selectedDays,
+  }) {
+    switch (recurrenceType.toLowerCase()) {
+      case "daily":
+        return endDate.difference(startDate).inDays ~/ interval;
+      case "weekly":
+        if (selectedDays != null && selectedDays.contains(true)) {
+          return _calculateWeeklyOccurrences(startDate, endDate, selectedDays);
+        }
+        return endDate.difference(startDate).inDays ~/ interval;
+      case "monthly":
+        return ((endDate.year - startDate.year) * 12 +
+                endDate.month -
+                startDate.month) ~/
+            1;
+      case "yearly":
+        return endDate.year - startDate.year;
+      default:
+        return 1;
+    }
+  }
+
+  /// helper function to calculate recurrence count per week
+  int _calculateWeeklyOccurrences(
+    DateTime startDate,
+    DateTime endDate,
+    List<bool> selectedDays, // [Sun, Mon, Tue, Wed, Thu, Fri, Sat]
+  ) {
+    int count = 0;
+    DateTime current = startDate;
+
+    while (!current.isAfter(endDate)) {
+      int weekdayIndex = current.weekday % 7;
+      // Dart: Mon=1..Sun=7, so %7 shifts Sun to 0
+      if (selectedDays[weekdayIndex]) {
+        count++;
+      }
+      current = current.add(const Duration(days: 1));
+    }
+
+    return count;
+  }
+
+  //CRUD Fucntion for editing tasks through this display
+  //Tasks can be edited to the system through other features and will appear in the Calendar
+
+  Future<void> _editTask(Task task) async {
+    final user = Provider.of<UserProvider>(context, listen: false).user;
+    if (user == null) return;
+    // Refresh task from backend so we always use latest recurrence
+    try {
+      final freshResponse = await ApiService.getTaskByIdV2(task.id);
+      if (freshResponse.statusCode == 200) {
+        final freshTask = Task.fromJson(jsonDecode(freshResponse.body));
+        task = freshTask; // replace with up-to-date task
+      } else {
+        print("⚠️ Failed to refresh task ${task.id}, using stale data");
+      }
+    } catch (e) {
+      print("⚠️ Error refreshing task ${task.id}: $e");
+    }
+    // Controllers
+    final titleController = TextEditingController(text: task.name);
+    final descriptionController = TextEditingController(text: task.description);
+    TimeOfDay? selectedTime = task.timeOfDay;
+    int? selectedPatientId = task.userId;
+
+    int? recDayOfMonth;
+
+    // ----- Prefill recurrence -----
+    // Is it recurring?
+    bool isRecurringLocal =
+        (task.frequency != null && task.frequency!.isNotEmpty) ||
+        ((task.daysOfWeek?.any((e) => e)) ?? false) ||
+        (task.taskType != null && task.taskType!.isNotEmpty);
+
+    // Determine recurrence type to show
+    String? recurrenceTypeLocal;
+    if (task.daysOfWeek != null && task.daysOfWeek!.any((e) => e)) {
+      recurrenceTypeLocal = 'Weekly';
+    } else if (task.frequency != null && task.frequency!.isNotEmpty) {
+      switch (task.frequency!.toLowerCase()) {
+        case 'daily':
+          recurrenceTypeLocal = 'Daily';
+          break;
+        case 'weekly':
+          recurrenceTypeLocal = 'Weekly';
+          break;
+        case 'monthly':
+          recurrenceTypeLocal = 'Monthly';
+          break;
+        case 'yearly':
+          recurrenceTypeLocal = 'Yearly';
+          break;
+        default:
+          recurrenceTypeLocal = null;
+      }
+    } else if (task.taskType != null) {
+      final tt = task.taskType!.toLowerCase();
+      if (tt == 'dayofweek') recurrenceTypeLocal = 'Weekly';
+      if (tt == 'frequency')
+        recurrenceTypeLocal = recurrenceTypeLocal ?? 'Daily';
+    }
+
+    // If monthly, pre-fill the day of month from the task.date
+    if (recurrenceTypeLocal == 'Monthly') {
+      recDayOfMonth = task.date.day;
+    }
+
+    List<bool>? daysOfWeekLocal = task.daysOfWeek;
+    int? intervalLocal = task.interval;
+    int? countLocal = task.count;
+    DateTime? startDateLocal = task.date;
+    DateTime?
+    endDateLocal; // not persisted in v2 – only used for UI math if you want
+    // ----- Caregiver: fetch patients for dropdown -----
+    List<Map<String, dynamic>> patients = [];
+    if (user.isCaregiver) {
+      final response = await ApiService.getCaregiverPatients(user.id);
+      if (response.statusCode == 200) {
+        patients = List<Map<String, dynamic>>.from(jsonDecode(response.body));
+      }
+    }
+
+    if (!mounted) return;
+
+    if (task.count != null && task.frequency != null && task.count! > 0) {
+      switch (task.frequency!.toLowerCase()) {
+        case "daily":
+          endDateLocal = task.date.add(
+            Duration(days: (task.count! - 1) * (task.interval ?? 1)),
+          );
+          break;
+        case "weekly":
+          endDateLocal = task.date.add(Duration(days: (task.count! - 1) * 7));
+          break;
+        case "monthly":
+          endDateLocal = DateTime(
+            task.date.year,
+            task.date.month + (task.count ?? 1) - 1,
+            task.date.day,
+          );
+          break;
+        case "yearly":
+          endDateLocal = DateTime(
+            task.date.year + (task.count ?? 1) - 1,
+            task.date.month,
+            task.date.day,
+          );
+          break;
+      }
+    }
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setInnerState) => AlertDialog(
+            title: const Text("Edit Task"),
+            content: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // Title
+                  TextField(
+                    controller: titleController,
+                    decoration: const InputDecoration(
+                      labelText: "Task Title",
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+
+                  // Description
+                  TextField(
+                    controller: descriptionController,
+                    maxLines: 3,
+                    decoration: const InputDecoration(
+                      labelText: "Description",
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+
+                  // Time picker
+                  Row(
+                    children: [
+                      const Text("Time: "),
+                      Text(
+                        selectedTime != null
+                            ? "${selectedTime!.hour.toString().padLeft(2, '0')}:${selectedTime!.minute.toString().padLeft(2, '0')}"
+                            : "Not set",
+                      ),
+                      const Spacer(),
+                      ElevatedButton(
+                        onPressed: () async {
+                          final picked = await showTimePicker(
+                            context: context,
+                            initialTime: selectedTime ?? TimeOfDay.now(),
+                          );
+                          if (picked != null) {
+                            setInnerState(() => selectedTime = picked);
+                          }
+                        },
+                        child: const Text("Pick Time"),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+
+                  // Caregiver assignment dropdown
+                  if (user.isPatient)
+                    Text("Assigned to: ${user.name}")
+                  else if (user.isCaregiver)
+                    DropdownButtonFormField<int>(
+                      decoration: const InputDecoration(
+                        labelText: "Assign to Patient",
+                        border: OutlineInputBorder(),
+                      ),
+                      value: selectedPatientId,
+                      items: patients.map((p) {
+                        return DropdownMenuItem<int>(
+                          value: p['patient']?['id'],
+                          child: Text(
+                            "${p['patient']?['firstName']} ${p['patient']?['lastName']}",
+                          ),
+                        );
+                      }).toList(),
+                      onChanged: (val) {
+                        setInnerState(() => selectedPatientId = val);
+                      },
+                    ),
+
+                  const SizedBox(height: 16),
+
+                  // Recurrence (reused component)
+                  RecurrenceForm(
+                    initialIsRecurring: isRecurringLocal,
+                    initialRecurrenceType: recurrenceTypeLocal,
+                    initialDaysOfWeek: daysOfWeekLocal,
+                    initialInterval: intervalLocal,
+                    initialCount: countLocal,
+                    initialStartDate: startDateLocal,
+                    initialEndDate: endDateLocal,
+                    initialDayOfMonth: recDayOfMonth,
+                    onChanged:
+                        ({
+                          bool? isRecurring,
+                          String? recurrenceType,
+                          List<bool>? daysOfWeek,
+                          int? interval,
+                          int? count,
+                          DateTime? startDate,
+                          DateTime? endDate,
+                          int? dayOfMonth,
+                        }) {
+                          setInnerState(() {
+                            // If recurrence type is set, force isRecurring = true
+                            if (recurrenceType != null &&
+                                recurrenceType.isNotEmpty) {
+                              isRecurringLocal = true;
+                            } else {
+                              isRecurringLocal = isRecurring ?? false;
+                            }
+                            recurrenceTypeLocal = recurrenceType;
+                            daysOfWeekLocal = daysOfWeek;
+                            intervalLocal = interval;
+                            countLocal = count;
+                            startDateLocal = startDate;
+                            endDateLocal = endDate;
+                            recDayOfMonth = dayOfMonth;
+                          });
+                        },
+                  ),
+                ],
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: const Text("Cancel"),
+              ),
+              ElevatedButton(
+                onPressed:
+                    (isRecurringLocal &&
+                        (recurrenceTypeLocal == null ||
+                            recurrenceTypeLocal!.isEmpty))
+                    ? null // disable if invalid
+                    : () {
+                        if (user.isCaregiver && selectedPatientId == null) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text("Please select a patient"),
+                            ),
+                          );
+                          return;
+                        }
+                        Navigator.pop(context, true);
+                      },
+                child: const Text("Save"),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+
+    if (confirmed != true) return;
+
+    // Final patientId logic
     final patientId = user.isPatient ? user.id : selectedPatientId!;
 
-    // Build updated task object
+    // Normalize recurrence for payload
+    String? frequencyToSend;
+    String? taskTypeToSend;
+    List<bool>? daysToSend = daysOfWeekLocal;
+    int? intervalToSend = intervalLocal;
+    int? countToSend = countLocal;
+
+    if (isRecurringLocal && (recurrenceTypeLocal != null)) {
+      switch (recurrenceTypeLocal) {
+        case 'Daily':
+          frequencyToSend = 'daily';
+          intervalToSend = intervalToSend ?? 1; // default
+          taskTypeToSend = 'frequency';
+          break;
+        case 'Weekly':
+          frequencyToSend = 'weekly';
+          intervalToSend = intervalToSend ?? 7; // your chosen convention
+          taskTypeToSend = (daysToSend != null && daysToSend.any((e) => e))
+              ? 'dayOfWeek'
+              : 'frequency';
+          break;
+        case 'Monthly':
+          frequencyToSend = 'monthly';
+          intervalToSend = intervalToSend ?? 1;
+          taskTypeToSend = 'frequency';
+          break;
+        case 'Yearly':
+          frequencyToSend = 'yearly';
+          intervalToSend = intervalToSend ?? 365;
+          taskTypeToSend = 'frequency';
+          break;
+      }
+    } else {
+      frequencyToSend = null;
+      intervalToSend = null;
+      countToSend = null;
+      daysToSend = null;
+      taskTypeToSend = 'task';
+    }
+
+    // Override date if monthly recurrence has a chosen day
+    DateTime effectiveDate = startDateLocal ?? task.date;
+
+    if (recurrenceTypeLocal?.toLowerCase() == 'monthly' &&
+        recDayOfMonth != null) {
+      final daysInMonth = DateUtils.getDaysInMonth(
+        effectiveDate.year,
+        effectiveDate.month,
+      );
+      final dom = recDayOfMonth!.clamp(1, daysInMonth);
+      effectiveDate = DateTime(effectiveDate.year, effectiveDate.month, dom);
+    }
+
+    // Recompute count if start+end chosen
+    if (startDateLocal != null &&
+        endDateLocal != null &&
+        recurrenceTypeLocal != null) {
+      switch (recurrenceTypeLocal!.toLowerCase()) {
+        case 'daily':
+          countToSend =
+              ((endDateLocal!.difference(startDateLocal!).inDays) ~/
+                  (intervalToSend ?? 1)) +
+              1;
+          break;
+        case 'weekly':
+          countToSend =
+              ((endDateLocal!.difference(startDateLocal!).inDays) ~/ 7) + 1;
+          break;
+        case 'monthly':
+          countToSend =
+              ((endDateLocal!.year - startDateLocal!.year) * 12 +
+                  (endDateLocal!.month - startDateLocal!.month)) +
+              1;
+          break;
+        case 'yearly':
+          countToSend = (endDateLocal!.year - startDateLocal!.year) + 1;
+          break;
+      }
+    }
+    print(
+      "🧭 Final effectiveDate = $effectiveDate "
+      "(start=$startDateLocal, end=$endDateLocal, dom=$recDayOfMonth)",
+    );
+    // Build updated Task (Task.toJson already includes patientId)
     final updatedTask = Task(
       id: task.id,
       name: titleController.text,
       description: descriptionController.text,
-      date: task.date,
+      date: effectiveDate, // keep same date unless you add a date picker
       timeOfDay: selectedTime,
       userId: patientId,
       isComplete: task.isComplete,
       notifications: task.notifications,
-      frequency: task.frequency,
-      interval: task.interval,
-      count: task.count,
-      daysOfWeek: task.daysOfWeek,
+      frequency: frequencyToSend,
+      interval: intervalToSend,
+      count: countToSend,
+      daysOfWeek: daysToSend,
+      taskType: taskTypeToSend,
     );
 
     try {
+      print("🚀 Sending edit payload: ${jsonEncode(updatedTask.toJson())}");
       final response = await ApiService.editTaskV2(
         task.id,
         updatedTask.toJson(),
       );
 
-      //Edit message sent if good response then make sure the class updates from DB
       if (response.statusCode == 200) {
         await _loadTasksFromDb();
         if (!mounted) return;
@@ -742,16 +1225,14 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
       } else {
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text("Failed to edit task: ${response.statusCode}"),
-          ),
+          SnackBar(content: Text("Failed: ${response.statusCode}")),
         );
       }
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text("Error editing task: $e")));
+      ).showSnackBar(SnackBar(content: Text("Error: $e")));
     }
   }
 
@@ -804,5 +1285,330 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         context,
       ).showSnackBar(SnackBar(content: Text("Error deleting task: $e")));
     }
+  }
+}
+
+// =============================
+// RecurrenceForm Widget
+// =============================
+class RecurrenceForm extends StatefulWidget {
+  final void Function({
+    bool? isRecurring,
+    String? recurrenceType,
+    List<bool>? daysOfWeek,
+    int? interval,
+    int? count,
+    DateTime? startDate,
+    DateTime? endDate,
+    int? dayOfMonth,
+  })
+  onChanged;
+
+  final bool initialIsRecurring;
+  final String? initialRecurrenceType;
+  final List<bool>? initialDaysOfWeek;
+  final int? initialInterval;
+  final int? initialCount;
+  final DateTime? initialStartDate;
+  final DateTime? initialEndDate;
+  final int? initialDayOfMonth;
+
+  const RecurrenceForm({
+    super.key,
+    required this.onChanged,
+    this.initialIsRecurring = false,
+    this.initialRecurrenceType,
+    this.initialDaysOfWeek,
+    this.initialInterval,
+    this.initialCount,
+    this.initialStartDate,
+    this.initialEndDate,
+    this.initialDayOfMonth,
+  });
+
+  @override
+  State<RecurrenceForm> createState() => _RecurrenceFormState();
+}
+
+class _RecurrenceFormState extends State<RecurrenceForm> {
+  bool isRecurring = false;
+  String? recurrenceType;
+  List<bool>? daysOfWeek;
+  int? interval;
+  int? count;
+  DateTime? startDate;
+  DateTime? endDate;
+  int? dayOfMonth;
+
+  @override
+  void initState() {
+    super.initState();
+    isRecurring = widget.initialIsRecurring;
+    recurrenceType = widget.initialRecurrenceType;
+    daysOfWeek = widget.initialDaysOfWeek;
+    interval = widget.initialInterval;
+    count = widget.initialCount;
+    startDate = widget.initialStartDate;
+    endDate = widget.initialEndDate;
+    dayOfMonth = widget.initialDayOfMonth;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        CheckboxListTile(
+          title: const Text("Recurring Task"),
+          value: isRecurring,
+          onChanged: (val) {
+            setState(() => isRecurring = val ?? false);
+
+            widget.onChanged(
+              isRecurring: isRecurring,
+              recurrenceType: recurrenceType,
+              daysOfWeek: daysOfWeek,
+              interval: interval,
+              count: count,
+              startDate: startDate,
+              endDate: endDate,
+              dayOfMonth: dayOfMonth,
+            );
+          },
+        ),
+
+        if (isRecurring) ...[
+          const SizedBox(height: 8),
+
+          // Recurrence Type Dropdown
+          DropdownButtonFormField<String>(
+            decoration: const InputDecoration(labelText: "Recurrence Type"),
+            value: recurrenceType,
+            items: [
+              "Daily",
+              "Weekly",
+              "Monthly",
+              "Yearly",
+            ].map((t) => DropdownMenuItem(value: t, child: Text(t))).toList(),
+            onChanged: (val) {
+              setState(() => recurrenceType = val);
+
+              widget.onChanged(
+                isRecurring: isRecurring,
+                recurrenceType: recurrenceType,
+                daysOfWeek: daysOfWeek,
+                interval: interval,
+                count: count,
+                startDate: startDate,
+                endDate: endDate,
+                dayOfMonth: dayOfMonth,
+              );
+            },
+          ),
+          // Inline warning message
+          if (isRecurring &&
+              (recurrenceType == null || recurrenceType!.isEmpty))
+            const Padding(
+              padding: EdgeInsets.only(top: 8.0, left: 4.0),
+              child: Text(
+                "⚠ Please select a recurrence type",
+                style: TextStyle(color: Colors.red, fontSize: 12),
+              ),
+            ),
+          const SizedBox(height: 16),
+
+          // Weekly → day-of-week picker
+          if (recurrenceType == "Weekly") ...[
+            const Text("Select Days of Week"),
+            Wrap(
+              spacing: 8,
+              children: List.generate(7, (index) {
+                const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+                return FilterChip(
+                  label: Text(days[index]),
+                  selected: (daysOfWeek ?? List.filled(7, false))[index],
+                  onSelected: (selected) {
+                    setState(() {
+                      daysOfWeek ??= List.filled(7, false);
+                      daysOfWeek![index] = selected;
+                    });
+                    widget.onChanged(
+                      isRecurring: isRecurring,
+                      recurrenceType: recurrenceType,
+                      daysOfWeek: daysOfWeek,
+                      interval: interval,
+                      count: count,
+                      startDate: startDate,
+                      endDate: endDate,
+                      dayOfMonth: dayOfMonth,
+                    );
+                  },
+                );
+              }),
+            ),
+          ],
+
+          // Monthly → day-of-month picker
+          if (recurrenceType == "Monthly") ...[
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                const Text("Day of Month:"),
+                const SizedBox(width: 12),
+                DropdownButton<int>(
+                  value: dayOfMonth,
+                  hint: const Text("Select Day"),
+                  items: List.generate(31, (i) => i + 1)
+                      .map(
+                        (d) => DropdownMenuItem(
+                          value: d,
+                          child: Text(d.toString()),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (val) {
+                    setState(() => dayOfMonth = val);
+                    widget.onChanged(
+                      isRecurring: isRecurring,
+                      recurrenceType: recurrenceType,
+                      daysOfWeek: daysOfWeek,
+                      interval: interval,
+                      count: count,
+                      startDate: startDate,
+                      endDate: endDate,
+                      dayOfMonth: dayOfMonth,
+                    );
+                  },
+                ),
+              ],
+            ),
+          ],
+          // Start Date Picker
+          Row(
+            children: [
+              Text(
+                startDate != null
+                    ? (recurrenceType == "Yearly"
+                          // If yearly, clarify this is the day/month
+                          ? "Occurs: ${startDate!.month}/${startDate!.day}"
+                          : "Starts: ${startDate!.toLocal().toString().split(' ')[0]}")
+                    : (recurrenceType == "Yearly"
+                          ? "No yearly day/month set"
+                          : "No start date set"),
+              ),
+              const Spacer(),
+              TextButton(
+                onPressed: () async {
+                  final picked = await showDatePicker(
+                    context: context,
+                    initialDate: startDate ?? DateTime.now(),
+                    firstDate: DateTime(2000), // allow past
+                    lastDate: DateTime(DateTime.now().year + 5),
+                  );
+                  if (picked != null) {
+                    setState(() => startDate = picked);
+                    widget.onChanged(
+                      isRecurring: isRecurring,
+                      recurrenceType: recurrenceType,
+                      daysOfWeek: daysOfWeek,
+                      interval: interval,
+                      count: count,
+                      endDate: endDate,
+                      dayOfMonth: dayOfMonth,
+                      startDate: startDate,
+                    );
+                  }
+                },
+                child: Text(
+                  recurrenceType == "Yearly"
+                      ? "Pick Day/Month"
+                      : "Pick Start Date",
+                ),
+              ),
+            ],
+          ),
+
+          // End Date OR End Year Picker
+          const SizedBox(height: 16),
+          if (recurrenceType == "Yearly") ...[
+            Row(
+              children: [
+                Text(
+                  endDate != null
+                      ? "Ends in Year: ${endDate!.year}"
+                      : "No end year set",
+                ),
+                const SizedBox(width: 12),
+                DropdownButton<int>(
+                  hint: const Text("Select End Year"),
+                  value: endDate?.year,
+                  items:
+                      List.generate(
+                        10, // next 10 years
+                        (i) => DateTime.now().year + i,
+                      ).map((year) {
+                        return DropdownMenuItem(
+                          value: year,
+                          child: Text(year.toString()),
+                        );
+                      }).toList(),
+                  onChanged: (val) {
+                    if (val != null) {
+                      // Store as Jan 1 of that year (you only care about year)
+                      setState(() => endDate = DateTime(val, 1, 1));
+                      widget.onChanged(
+                        isRecurring: isRecurring,
+                        recurrenceType: recurrenceType,
+                        daysOfWeek: daysOfWeek,
+                        interval: interval,
+                        count: count,
+                        endDate: endDate,
+                        startDate: startDate,
+                        dayOfMonth: dayOfMonth,
+                      );
+                    }
+                  },
+                ),
+              ],
+            ),
+          ] else ...[
+            Row(
+              children: [
+                Text(
+                  endDate != null
+                      ? "Ends: ${endDate!.toLocal().toString().split(' ')[0]}"
+                      : "No end date set",
+                ),
+                const Spacer(),
+                TextButton(
+                  onPressed: () async {
+                    final picked = await showDatePicker(
+                      context: context,
+                      initialDate: endDate ?? DateTime.now(),
+                      firstDate: DateTime.now(),
+                      lastDate: DateTime(DateTime.now().year + 5),
+                    );
+                    if (picked != null) {
+                      setState(() => endDate = picked);
+                      widget.onChanged(
+                        isRecurring: isRecurring,
+                        recurrenceType: recurrenceType,
+                        daysOfWeek: daysOfWeek,
+                        interval: interval,
+                        count: count,
+                        endDate: endDate,
+                        startDate: startDate,
+                        dayOfMonth: dayOfMonth,
+                      );
+                    }
+                  },
+                  child: const Text("Pick End Date"),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ],
+    );
   }
 }

--- a/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
@@ -1,5 +1,5 @@
 // =============================
-// CalendarAssistantScreen.dart
+// CalendarAssistantScreen
 // =============================
 
 import 'dart:collection';
@@ -14,6 +14,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:table_calendar/table_calendar.dart';
 
+// =============================
+// TaskCopyWith
+// =============================
 extension TaskCopyWith on Task {
   Task copyWith({
     int? id,
@@ -89,6 +92,9 @@ class TaskUtils {
   }
 }
 
+// =============================
+// RecurrenceUtils
+// =============================
 /// Utilities for building recurring tasks consistently
 class RecurrenceUtils {
   static Task buildTask({
@@ -174,7 +180,7 @@ class RecurrenceUtils {
             final months =
                 (endDate.year - effectiveDate.year) * 12 +
                 (endDate.month - effectiveDate.month);
-            countToSend = (months ~/ intervalToSend!) + 1;
+            countToSend = (months ~/ intervalToSend) + 1;
           } else {
             countToSend ??= 12; // default: 12 months
           }
@@ -317,7 +323,9 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     _loadTasksFromDb();
   }
 
+  ///This function is used across the assistant to query task information from the DB
   Future<void> _loadTasksFromDb() async {
+    if (!mounted) return;
     setState(() {
       isLoading = true;
       error = null;
@@ -365,6 +373,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     }
   }
 
+  /// Using V2 of endpoint, fetch the need task information
   Future<List<Task>> _fetchTasksForPatient(int patientId) async {
     final tasks = <Task>[];
 
@@ -401,6 +410,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     return tasks;
   }
 
+  /// Build fucntion to actual make the Calendar Assistant
   @override
   Widget build(BuildContext context) {
     if (isLoading) {
@@ -410,7 +420,6 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         body: const Center(child: CircularProgressIndicator()),
       );
     }
-
     return Scaffold(
       drawer: const CommonDrawer(currentRoute: '/calendar'),
       appBar: AppBarHelper.createAppBar(
@@ -465,7 +474,6 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
                 ),
               ),
               const SizedBox(height: 16),
-
               // Legend
               Padding(
                 padding: const EdgeInsets.all(8.0),
@@ -477,14 +485,13 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
                 ),
               ),
               const SizedBox(height: 16),
-
               // Task list for selected day
               if (_selectedDay != null && tasks[_selectedDay] != null)
                 Builder(
                   builder: (_) {
                     final dayTasks = [...tasks[_selectedDay]!];
 
-                    // ✅ Sort chronologically by timeOfDay
+                    //Sort chronologically by timeOfDay
                     dayTasks.sort((a, b) {
                       if (a.timeOfDay != null && b.timeOfDay != null) {
                         final aMinutes =
@@ -567,10 +574,10 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     );
   }
 
+  /// This fucntion is used to add a task to the CareConnect system
   Future<void> _addTask() async {
     final user = Provider.of<UserProvider>(context, listen: false).user;
     if (user == null) return;
-
     // Preload patients if caregiver
     List<Map<String, dynamic>> patients = [];
     if (user.isCaregiver) {
@@ -579,8 +586,8 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         patients = List<Map<String, dynamic>>.from(jsonDecode(response.body));
       }
     }
-
     // Show dialog
+    if (!mounted) return;
     final draftTask = await showDialog<Task>(
       context: context,
       builder: (_) => TaskFormDialog(
@@ -591,15 +598,13 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     );
 
     if (draftTask == null) return;
-
     final newTask = RecurrenceUtils.buildTask(baseTask: draftTask);
-
     try {
       final response = await ApiService.createTaskV2(
         newTask.userId!,
         jsonEncode(newTask.toJson()),
       );
-
+      if (!mounted) return;
       if (response.statusCode == 200) {
         await _loadTasksFromDb();
         if (!mounted) return;
@@ -620,6 +625,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     }
   }
 
+  /// This function is to edit tasks in the CareConnect system displayed by the Calendar Assistant
   Future<void> _editTask(Task task) async {
     final user = Provider.of<UserProvider>(context, listen: false).user;
     if (user == null) return;
@@ -631,7 +637,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         task = Task.fromJson(jsonDecode(freshResponse.body));
       }
     } catch (e) {
-      debugPrint("⚠️ Error refreshing task ${task.id}: $e");
+      debugPrint("Error refreshing task ${task.id}: $e");
     }
 
     // Preload patients if caregiver
@@ -644,6 +650,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     }
 
     // Show edit form
+    if (!mounted) return;
     final editedTask = await showDialog<Task>(
       context: context,
       builder: (_) => TaskFormDialog(
@@ -656,7 +663,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
 
     if (editedTask == null) return;
 
-    // ✅ Use RecurrenceUtils to normalize recurrence
+    //normalize recurrence
     final newTask = RecurrenceUtils.buildTask(baseTask: editedTask);
 
     try {
@@ -669,13 +676,13 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         await _loadTasksFromDb();
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text("✅ Task updated successfully")),
+          const SnackBar(content: Text("Task updated successfully")),
         );
       } else {
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text("⚠️ Failed to update task: ${response.statusCode}"),
+            content: Text("Failed to update task: ${response.statusCode}"),
           ),
         );
       }
@@ -683,10 +690,11 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text("❌ Error updating task: $e")));
+      ).showSnackBar(SnackBar(content: Text("Error updating task: $e")));
     }
   }
 
+  /// This function is to remove tasks in the CareConnect system displayed by the Calendar Assistant
   Future<void> _removeTask(Task task) async {
     final confirmed = await showDialog<bool>(
       context: context,
@@ -740,7 +748,8 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
 // =============================
 // TaskFormDialog.dart
 // =============================
-
+/// Since Add and Edit use the same form for tasks that logic is broken up here into two forms one being the TaskFormDialog and the other being the RecurrenceForm.
+/// This allows functionality of the forms to be chared across the code.
 class TaskFormDialog extends StatefulWidget {
   final Task? initialTask;
   final bool isCaregiver;
@@ -834,6 +843,7 @@ class _TaskFormDialogState extends State<TaskFormDialog> {
     }
   }
 
+  //TODO This needs to be implemented better based off of setting Task Type
   String? _inferRecurrenceTypeFromTask(Task t) {
     if (t.daysOfWeek?.any((d) => d) ?? false) return "Weekly";
     switch (t.frequency?.toLowerCase()) {
@@ -850,7 +860,7 @@ class _TaskFormDialogState extends State<TaskFormDialog> {
     }
   }
 
-  /// validation logic
+  /// validation logic of the form's save button
   bool get canSave {
     // Must have a name
     if (titleController.text.trim().isEmpty) return false;
@@ -858,14 +868,12 @@ class _TaskFormDialogState extends State<TaskFormDialog> {
     if (isRecurring) {
       // Must have a recurrence type
       if (recurrenceType == null || recurrenceType!.isEmpty) return false;
-
       // Weekly: require at least one day
       if (recurrenceType!.toLowerCase() == "weekly") {
         if (daysOfWeek == null || !daysOfWeek!.any((d) => d)) {
           return false;
         }
       }
-
       // Must have an end condition (endDate or count)
       if ((endDate == null || endDate!.isBefore(startDate ?? DateTime.now())) &&
           (count == null || count! <= 0)) {
@@ -876,6 +884,7 @@ class _TaskFormDialogState extends State<TaskFormDialog> {
     return true;
   }
 
+  ///Building the task form based on Add or Edit function
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
@@ -929,6 +938,7 @@ class _TaskFormDialogState extends State<TaskFormDialog> {
             ),
             const SizedBox(height: 12),
 
+            /// If caregiver then allow assignment to patient. If patient always assigned to themseleves.
             // Caregiver dropdown
             if (widget.isCaregiver)
               DropdownButtonFormField<int>(
@@ -936,7 +946,7 @@ class _TaskFormDialogState extends State<TaskFormDialog> {
                   labelText: "Assign to Patient",
                   border: OutlineInputBorder(),
                 ),
-                value: selectedPatientId,
+                initialValue: selectedPatientId,
                 items: widget.patients.map((p) {
                   return DropdownMenuItem<int>(
                     value: p['patient']?['id'],
@@ -1024,7 +1034,7 @@ class _TaskFormDialogState extends State<TaskFormDialog> {
 
                   Navigator.pop(context, finalTask);
                 }
-              : null, // ✅ disabled if invalid
+              : null, //disabled if invalid
           child: const Text("Save"),
         ),
       ],
@@ -1035,6 +1045,7 @@ class _TaskFormDialogState extends State<TaskFormDialog> {
 // =============================
 // RecurrenceForm Widget
 // =============================
+///This widget allows mutiple places in the code to use the reoccurnce form portion, and ressue its functionality needed specifically for reoccurences.
 class RecurrenceForm extends StatefulWidget {
   final void Function({
     bool? isRecurring,
@@ -1097,7 +1108,7 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
     dayOfMonth = widget.initialDayOfMonth;
   }
 
-  // --- validation flags for inline error messages ---
+  //validation flags for inline error messages
   bool get isMissingType =>
       isRecurring && (recurrenceType == null || recurrenceType!.isEmpty);
 
@@ -1137,7 +1148,7 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
           // Recurrence type dropdown
           DropdownButtonFormField<String>(
             decoration: const InputDecoration(labelText: "Recurrence Type"),
-            value: recurrenceType,
+            initialValue: recurrenceType,
             items: [
               "Daily",
               "Weekly",
@@ -1162,7 +1173,7 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
             const Padding(
               padding: EdgeInsets.only(top: 4.0),
               child: Text(
-                "⚠ Please select a recurrence type",
+                "Please select a recurrence type",
                 style: TextStyle(color: Colors.red, fontSize: 12),
               ),
             ),
@@ -1198,7 +1209,7 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
               const Padding(
                 padding: EdgeInsets.only(top: 4.0),
                 child: Text(
-                  "⚠ Please select at least one day of the week",
+                  "Please select at least one day of the week",
                   style: TextStyle(color: Colors.red, fontSize: 12),
                 ),
               ),
@@ -1239,9 +1250,7 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
               ],
             ),
           ],
-
           const SizedBox(height: 16),
-
           // Start date picker
           Row(
             children: [
@@ -1277,9 +1286,7 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
               ),
             ],
           ),
-
           const SizedBox(height: 12),
-
           // End date picker
           Row(
             children: [
@@ -1320,7 +1327,7 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
             const Padding(
               padding: EdgeInsets.only(top: 4.0),
               child: Text(
-                "⚠ Please provide an end date of the series",
+                "Please provide an end date of the series",
                 style: TextStyle(color: Colors.red, fontSize: 12),
               ),
             ),

--- a/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
@@ -90,6 +90,11 @@ class TaskUtils {
     }
     return grouped;
   }
+
+  /// Normalize a date to local midnight (drops hours/minutes/seconds).
+  static DateTime normalizeDate(DateTime d) {
+    return DateTime(d.year, d.month, d.day);
+  }
 }
 
 // =============================
@@ -109,12 +114,18 @@ class RecurrenceUtils {
     int? dayOfMonth,
   }) {
     String? frequency;
-    String? taskType;
     int? intervalToSend = interval;
     int? countToSend = count;
 
+    // Preserve original task type safely
+    final normalizedTaskType = baseTask.taskType?.toLowerCase();
+
     // Default effective start date
-    DateTime effectiveDate = startDate ?? baseTask.date;
+    DateTime effectiveDate = (startDate ?? baseTask.date).toLocal();
+    // Normalize end date if provided
+    DateTime? normalizedEndDate = endDate != null
+        ? TaskUtils.normalizeDate(endDate)
+        : null;
 
     if (isRecurring == true && recurrenceType != null) {
       switch (recurrenceType.toLowerCase()) {
@@ -124,13 +135,14 @@ class RecurrenceUtils {
               ? 1
               : intervalToSend;
 
-          if (endDate != null) {
-            final daysBetween = endDate.difference(effectiveDate).inDays;
+          if (normalizedEndDate != null) {
+            final daysBetween = normalizedEndDate
+                .difference(effectiveDate)
+                .inDays;
             countToSend = (daysBetween ~/ intervalToSend) + 1;
           } else {
             countToSend ??= 30; // fallback: 30 days if no end date
           }
-          taskType = "frequency";
           break;
 
         case "weekly":
@@ -139,21 +151,18 @@ class RecurrenceUtils {
               ? 1
               : intervalToSend;
 
-          if (endDate != null) {
+          if (normalizedEndDate != null) {
             final totalWeeks =
-                (endDate.difference(effectiveDate).inDays ~/ 7) + 1;
+                (normalizedEndDate.difference(effectiveDate).inDays ~/ 7) + 1;
 
             if (daysOfWeek != null && daysOfWeek.any((d) => d)) {
               final selectedDays = daysOfWeek.where((d) => d).length;
               countToSend = totalWeeks * selectedDays;
-              taskType = "dayOfWeek";
             } else {
               countToSend = totalWeeks;
-              taskType = "frequency";
             }
           } else {
             countToSend ??= 4; // default 4 weeks if no end date
-            taskType = "frequency";
           }
           break;
 
@@ -176,16 +185,14 @@ class RecurrenceUtils {
             );
           }
 
-          if (endDate != null) {
+          if (normalizedEndDate != null) {
             final months =
-                (endDate.year - effectiveDate.year) * 12 +
-                (endDate.month - effectiveDate.month);
+                (normalizedEndDate.year - effectiveDate.year) * 12 +
+                (normalizedEndDate.month - effectiveDate.month);
             countToSend = (months ~/ intervalToSend) + 1;
           } else {
             countToSend ??= 12; // default: 12 months
           }
-
-          taskType = "frequency";
           break;
 
         case "yearly":
@@ -194,26 +201,66 @@ class RecurrenceUtils {
               ? 1
               : intervalToSend;
 
-          if (endDate != null) {
-            final years = endDate.year - effectiveDate.year;
+          if (normalizedEndDate != null) {
+            final years = normalizedEndDate.year - effectiveDate.year;
             countToSend = (years ~/ intervalToSend) + 1;
           } else {
             countToSend ??= 5; // default: 5 years
           }
-
-          taskType = "frequency";
           break;
       }
     }
-
     return baseTask.copyWith(
       date: effectiveDate,
       frequency: frequency,
       interval: intervalToSend,
       count: countToSend,
       daysOfWeek: daysOfWeek,
-      taskType: taskType,
     );
+  }
+}
+
+// =============================
+// TaskTypeUtils.dart
+// =============================
+///Moving task Types into utility class for use across code base
+class TaskTypeUtils {
+  static final Map<String, Color> taskTypeColors = {
+    'medication': Colors.red,
+    'appointment': Colors.blue,
+    'exercise': Colors.green,
+    'general': Colors.deepOrange,
+    'lab': Colors.purple,
+    'pharmacy': Colors.teal,
+  };
+
+  /// Map used to change icon used for certain types of task
+  static final Map<String, IconData> taskTypeIcons = {
+    'medication': Icons.medication,
+    'appointment': Icons.event,
+    'exercise': Icons.fitness_center,
+    'general': Icons.task,
+    'lab': Icons.science,
+    'pharmacy': Icons.local_pharmacy,
+  };
+
+  /// Get a color safely with fallback
+  static Color getColor(String? type) {
+    if (type == null) return Colors.deepOrange;
+    return taskTypeColors[type.toLowerCase()] ?? Colors.deepOrange;
+  }
+
+  /// Get icon safely
+  static IconData getIcon(String? type) {
+    if (type == null) return taskTypeIcons['general']!;
+    return taskTypeIcons[type.toLowerCase()] ?? taskTypeIcons['general']!;
+  }
+
+  /// Get an alphabetized list of task type keys
+  static List<String> getSortedTypes() {
+    final keys = taskTypeColors.keys.toList();
+    keys.sort();
+    return keys;
   }
 }
 
@@ -239,22 +286,6 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     hashCode: (date) => date.day * 1000000 + date.month * 10000 + date.year,
   );
   Map<int, String> patientNames = {};
-
-  final Map<String, Color> taskTypeColors = {
-    'medication': Colors.red,
-    'appointment': Colors.blue,
-    'exercise': Colors.green,
-    'general': Colors.deepOrange,
-    'lab': Colors.purple,
-    'pharmacy': Colors.teal,
-    'medical': Colors.cyan,
-  };
-
-  /// Map task type to color
-  Color _getTaskColor(String type) {
-    final key = type.toLowerCase();
-    return taskTypeColors[key] ?? Colors.deepOrange;
-  }
 
   /// Build a small colored dot + label for the legend
   Widget _buildLegendDot(Color color, String label) {
@@ -285,7 +316,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
           margin: const EdgeInsets.symmetric(horizontal: 1, vertical: 1),
           decoration: BoxDecoration(
             shape: BoxShape.circle,
-            color: _getTaskColor(task.taskType ?? "general"),
+            color: TaskTypeUtils.getColor(task.taskType ?? "general"),
           ),
         ),
       if (dayTasks.length > maxVisibleDots)
@@ -389,7 +420,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
 
           try {
             final baseTask = Task.fromJson(map);
-            baseTask.date = baseTask.date.toLocal();
+            baseTask.date = TaskUtils.normalizeDate(baseTask.date.toLocal());
 
             // Expand recurrences
             final expanded = baseTask.expandOccurrences();
@@ -479,8 +510,13 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
                 padding: const EdgeInsets.all(8.0),
                 child: Wrap(
                   spacing: 16,
-                  children: taskTypeColors.entries
-                      .map((e) => _buildLegendDot(e.value, e.key))
+                  children: TaskTypeUtils.taskTypeColors.entries
+                      .map(
+                        (e) => _buildLegendDot(
+                          e.value,
+                          e.key[0].toUpperCase() + e.key.substring(1),
+                        ),
+                      )
                       .toList(),
                 ),
               ),
@@ -513,8 +549,8 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
 
                         return ListTile(
                           leading: Icon(
-                            Icons.task,
-                            color: _getTaskColor(task.taskType ?? "general"),
+                            TaskTypeUtils.getIcon(task.taskType),
+                            color: TaskTypeUtils.getColor(task.taskType),
                           ),
                           title: Text(
                             task.name,
@@ -594,6 +630,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         isCaregiver: user.isCaregiver,
         patients: patients,
         defaultPatientId: user.isPatient ? user.id : null,
+        initialDate: _selectedDay,
       ),
     );
 
@@ -635,6 +672,9 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
       final freshResponse = await ApiService.getTaskByIdV2(task.id);
       if (freshResponse.statusCode == 200) {
         task = Task.fromJson(jsonDecode(freshResponse.body));
+        task = task.copyWith(
+          date: TaskUtils.normalizeDate(task.date.toLocal()),
+        );
       }
     } catch (e) {
       debugPrint("Error refreshing task ${task.id}: $e");
@@ -658,6 +698,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         isCaregiver: user.isCaregiver,
         patients: patients,
         defaultPatientId: user.isPatient ? user.id : task.userId,
+        initialDate: _selectedDay,
       ),
     );
 
@@ -665,7 +706,6 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
 
     //normalize recurrence
     final newTask = RecurrenceUtils.buildTask(baseTask: editedTask);
-
     try {
       final response = await ApiService.editTaskV2(
         newTask.id,
@@ -755,6 +795,7 @@ class TaskFormDialog extends StatefulWidget {
   final bool isCaregiver;
   final List<Map<String, dynamic>> patients;
   final int? defaultPatientId;
+  final DateTime? initialDate;
 
   const TaskFormDialog({
     super.key,
@@ -762,6 +803,7 @@ class TaskFormDialog extends StatefulWidget {
     required this.isCaregiver,
     required this.patients,
     this.defaultPatientId,
+    this.initialDate,
   });
 
   @override
@@ -773,6 +815,9 @@ class _TaskFormDialogState extends State<TaskFormDialog> {
   late TextEditingController descriptionController;
   TimeOfDay? selectedTime;
   int? selectedPatientId;
+  String? selectedTaskType;
+  // Pull task types directly here
+  late final List<String> taskTypes = TaskTypeUtils.getSortedTypes();
 
   // Recurrence state
   bool isRecurring = false;
@@ -794,7 +839,17 @@ class _TaskFormDialogState extends State<TaskFormDialog> {
     descriptionController = TextEditingController(text: t?.description ?? '');
     selectedTime = t?.timeOfDay;
     selectedPatientId = widget.defaultPatientId ?? t?.userId;
-
+    //If editing and taskType is valid, keep it
+    if (t != null &&
+        t.taskType != null &&
+        taskTypes.contains(t.taskType!.toLowerCase())) {
+      selectedTaskType = t.taskType!.toLowerCase();
+    } else {
+      // Otherwise default to "general"
+      selectedTaskType = taskTypes.contains("general")
+          ? "general"
+          : taskTypes.first;
+    }
     // ensure Save button re-checks when text changes
     titleController.addListener(() => setState(() {}));
 
@@ -839,11 +894,11 @@ class _TaskFormDialogState extends State<TaskFormDialog> {
         }
       }
     } else {
-      startDate = DateTime.now();
+      // Use initialDate from the calendar if passed, otherwise fallback to now
+      startDate = TaskUtils.normalizeDate(widget.initialDate ?? DateTime.now());
     }
   }
 
-  //TODO This needs to be implemented better based off of setting Task Type
   String? _inferRecurrenceTypeFromTask(Task t) {
     if (t.daysOfWeek?.any((d) => d) ?? false) return "Weekly";
     switch (t.frequency?.toLowerCase()) {
@@ -894,26 +949,54 @@ class _TaskFormDialogState extends State<TaskFormDialog> {
           mainAxisSize: MainAxisSize.min,
           children: [
             // Title
-            TextField(
+            TextFormField(
               controller: titleController,
               decoration: const InputDecoration(
                 labelText: "Task Title",
                 border: OutlineInputBorder(),
+                floatingLabelBehavior: FloatingLabelBehavior.always,
               ),
             ),
             const SizedBox(height: 12),
 
             // Description
-            TextField(
+            TextFormField(
               controller: descriptionController,
               maxLines: 3,
               decoration: const InputDecoration(
                 labelText: "Description",
                 border: OutlineInputBorder(),
+                floatingLabelBehavior: FloatingLabelBehavior.always,
               ),
             ),
             const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              decoration: const InputDecoration(
+                labelText: "Task Type",
+                border: OutlineInputBorder(),
+              ),
+              initialValue:
+                  selectedTaskType != null &&
+                      ![
+                        "daily",
+                        "weekly",
+                        "monthly",
+                        "yearly",
+                      ].contains(selectedTaskType!.toLowerCase())
+                  ? selectedTaskType
+                  : null,
+              items: taskTypes
+                  .map(
+                    (type) => DropdownMenuItem(
+                      value: type,
+                      child: Text(type[0].toUpperCase() + type.substring(1)),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (val) => setState(() => selectedTaskType = val),
+            ),
 
+            const SizedBox(height: 16),
             // Time picker
             Row(
               children: [
@@ -945,6 +1028,7 @@ class _TaskFormDialogState extends State<TaskFormDialog> {
                 decoration: const InputDecoration(
                   labelText: "Assign to Patient",
                   border: OutlineInputBorder(),
+                  floatingLabelBehavior: FloatingLabelBehavior.always,
                 ),
                 initialValue: selectedPatientId,
                 items: widget.patients.map((p) {
@@ -1017,7 +1101,11 @@ class _TaskFormDialogState extends State<TaskFormDialog> {
                     interval: interval,
                     count: count,
                     daysOfWeek: daysOfWeek,
-                    taskType: widget.initialTask?.taskType,
+                    taskType:
+                        (selectedTaskType ??
+                                widget.initialTask?.taskType ??
+                                "general")
+                            .toLowerCase(),
                   );
 
                   final finalTask = RecurrenceUtils.buildTask(
@@ -1103,8 +1191,14 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
     daysOfWeek = widget.initialDaysOfWeek ?? List.filled(7, false);
     interval = widget.initialInterval;
     count = widget.initialCount;
-    startDate = widget.initialStartDate;
-    endDate = widget.initialEndDate;
+    //Normalize incoming dates
+    startDate = widget.initialStartDate != null
+        ? TaskUtils.normalizeDate(widget.initialStartDate!)
+        : null;
+
+    endDate = widget.initialEndDate != null
+        ? TaskUtils.normalizeDate(widget.initialEndDate!)
+        : null;
     dayOfMonth = widget.initialDayOfMonth;
   }
 
@@ -1147,7 +1241,11 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
           const SizedBox(height: 8),
           // Recurrence type dropdown
           DropdownButtonFormField<String>(
-            decoration: const InputDecoration(labelText: "Recurrence Type"),
+            decoration: const InputDecoration(
+              labelText: "Recurrence Type",
+              border: OutlineInputBorder(),
+              floatingLabelBehavior: FloatingLabelBehavior.always,
+            ),
             initialValue: recurrenceType,
             items: [
               "Daily",
@@ -1269,7 +1367,7 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
                     lastDate: DateTime(DateTime.now().year + 5),
                   );
                   if (picked != null) {
-                    setState(() => startDate = picked);
+                    setState(() => startDate = TaskUtils.normalizeDate(picked));
                     widget.onChanged(
                       isRecurring: isRecurring,
                       recurrenceType: recurrenceType,
@@ -1288,40 +1386,84 @@ class _RecurrenceFormState extends State<RecurrenceForm> {
           ),
           const SizedBox(height: 12),
           // End date picker
-          Row(
-            children: [
-              Text(
-                endDate != null
-                    ? "Ends: ${endDate!.toLocal().toString().split(' ')[0]}"
-                    : "No end date set",
-              ),
-              const Spacer(),
-              TextButton(
-                onPressed: () async {
-                  final picked = await showDatePicker(
-                    context: context,
-                    initialDate: endDate ?? DateTime.now(),
-                    firstDate: DateTime.now(),
-                    lastDate: DateTime(DateTime.now().year + 5),
-                  );
-                  if (picked != null) {
-                    setState(() => endDate = picked);
-                    widget.onChanged(
-                      isRecurring: isRecurring,
-                      recurrenceType: recurrenceType,
-                      daysOfWeek: daysOfWeek,
-                      interval: interval,
-                      count: count,
-                      startDate: startDate,
-                      endDate: endDate,
-                      dayOfMonth: dayOfMonth,
+          if (recurrenceType != "Yearly") ...[
+            Row(
+              children: [
+                Text(
+                  endDate != null
+                      ? "Ends: ${endDate!.toLocal().toString().split(' ')[0]}"
+                      : "No end date set",
+                ),
+                const Spacer(),
+                TextButton(
+                  onPressed: () async {
+                    final picked = await showDatePicker(
+                      context: context,
+                      initialDate: endDate ?? startDate ?? DateTime.now(),
+                      firstDate: startDate ?? DateTime.now(),
+                      lastDate: DateTime(DateTime.now().year + 5),
                     );
-                  }
-                },
-                child: const Text("Pick End Date"),
-              ),
-            ],
-          ),
+                    if (picked != null) {
+                      setState(() => endDate = TaskUtils.normalizeDate(picked));
+                      widget.onChanged(
+                        isRecurring: isRecurring,
+                        recurrenceType: recurrenceType,
+                        daysOfWeek: daysOfWeek,
+                        interval: interval,
+                        count: count,
+                        startDate: startDate,
+                        endDate: endDate,
+                        dayOfMonth: dayOfMonth,
+                      );
+                    }
+                  },
+                  child: const Text("Pick End Date"),
+                ),
+              ],
+            ),
+          ] else if (recurrenceType == "Yearly") ...[
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                const Text("Ends in Year:"),
+                const SizedBox(width: 12),
+                DropdownButton<int>(
+                  value: endDate?.year,
+                  hint: const Text("Select Year"),
+                  items: List.generate(10, (i) => DateTime.now().year + i)
+                      .map(
+                        (y) => DropdownMenuItem(
+                          value: y,
+                          child: Text(y.toString()),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (val) {
+                    if (val != null && startDate != null) {
+                      setState(() {
+                        endDate = DateTime(
+                          val,
+                          startDate!.month,
+                          startDate!.day,
+                        );
+                        count = (val - startDate!.year) + 1; // auto-calc count
+                      });
+                      widget.onChanged(
+                        isRecurring: isRecurring,
+                        recurrenceType: recurrenceType,
+                        daysOfWeek: daysOfWeek,
+                        interval: interval,
+                        count: count,
+                        startDate: startDate,
+                        endDate: endDate,
+                        dayOfMonth: dayOfMonth,
+                      );
+                    }
+                  },
+                ),
+              ],
+            ),
+          ],
 
           if (isMissingEndCondition)
             const Padding(

--- a/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
@@ -38,10 +38,9 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
   );
 
   // Map patientId -> patient name
-  //This will be more required once the endpoint provides needed information.
   Map<int, String> patientNames = {};
 
-  // Define task types and their colors, also requires endpoint for more use.
+  // Define task types and their colors
   final Map<String, Color> taskTypeColors = {
     'medication': Colors.red,
     'appointment': Colors.blue,
@@ -80,7 +79,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
       //if caregiver then you see your patients events
       // --- PATIENT FLOW ---
       if (user.isPatient) {
-        final response = await ApiService.getPatientTasks(
+        final response = await ApiService.getPatientTasksV2(
           user.id,
         ).timeout(const Duration(seconds: 30));
         if (response.statusCode == 200) {
@@ -113,7 +112,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         final patientsResponse = await ApiService.getCaregiverPatients(user.id);
         if (patientsResponse.statusCode == 200) {
           final List patients = json.decode(patientsResponse.body);
-          //Need name information for assignements. This is to be refactored when endpoint is updated.
+          //Need name information for assignements
           for (var patient in patients) {
             final patientId = patient['patient']?['id'];
             final firstName = patient['patient']?['firstName'] ?? '';
@@ -129,7 +128,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
               continue;
             }
 
-            final taskResponse = await ApiService.getPatientTasks(
+            final taskResponse = await ApiService.getPatientTasksV2(
               patientId,
             ).timeout(const Duration(seconds: 30));
             if (taskResponse.statusCode == 200) {
@@ -268,15 +267,14 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
               // Task list with edit/remove buttons
               if (_selectedDay != null && tasks[_selectedDay] != null)
                 ...tasks[_selectedDay]!.map((task) {
-                  /* final assignedName = task.userId != null
+                  final assignedName = task.userId != null
                       ? patientNames[task.userId] ?? "Unknown Patient"
-                      : "Unassigned";*/
+                      : "Unassigned";
 
                   return ListTile(
                     leading: const Icon(Icons.task),
                     title: Text(
-                      //"$assignedName: ${task.name}", Will encoperate once endpoint is updated
-                      task.name,
+                      "$assignedName: ${task.name}",
                       style: const TextStyle(fontWeight: FontWeight.w500),
                     ),
                     trailing: Row(
@@ -304,7 +302,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
 
               const SizedBox(height: 16),
 
-              // Legend: needs refactoring based on update to taskType
+              // Legend
               Padding(
                 padding: const EdgeInsets.all(8.0),
                 child: Wrap(
@@ -337,7 +335,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     );
   }
 
-  /// Map task type to color, need clear taskType before logic returns anything but general color.
+  /// Map task type to color
   Color _getTaskColor(String type) {
     final key = type.toLowerCase();
     return taskTypeColors[key] ?? Colors.deepOrange;
@@ -349,7 +347,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     List<Widget> taskDots = [];
 
     final displayTasks = dayTasks.take(maxVisibleDots).toList();
-    for (var _ in displayTasks) {
+    for (var task in displayTasks) {
       taskDots.add(
         Container(
           width: 8,
@@ -357,8 +355,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
           margin: const EdgeInsets.symmetric(horizontal: 1, vertical: 1),
           decoration: BoxDecoration(
             shape: BoxShape.circle,
-            //TODO Need to figure out better system for checking colors if needed.
-            color: _getTaskColor("general"),
+            color: _getTaskColor(task.taskType ?? "general"),
           ),
         ),
       );
@@ -408,68 +405,122 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     final titleController = TextEditingController();
     final descriptionController = TextEditingController();
     TimeOfDay? selectedTime;
-    //Pop Up form for basic information to make a task
+    int? selectedPatientId;
+
+    // If caregiver, fetch patients for dropdown
+    List<Map<String, dynamic>> patients = [];
+    if (user.isCaregiver) {
+      final response = await ApiService.getCaregiverPatients(user.id);
+      if (response.statusCode == 200) {
+        patients = List<Map<String, dynamic>>.from(jsonDecode(response.body));
+      }
+    }
+    if (!mounted) return;
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) {
         return StatefulBuilder(
           builder: (context, setState) => Dialog(
-            //Padding and sizing set for control of viewable pop up space and to ensre
-            //form fields are not spawened  to top of each other.
             child: Padding(
               padding: const EdgeInsets.all(16),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  TextField(
-                    controller: titleController,
-                    decoration: const InputDecoration(labelText: "Task Title"),
-                  ),
-                  const SizedBox(height: 8),
-                  TextField(
-                    controller: descriptionController,
-                    decoration: const InputDecoration(labelText: "Description"),
-                  ),
-                  const SizedBox(height: 8),
-                  Row(
-                    children: [
-                      Text(
-                        selectedTime != null
-                            ? "Time: ${selectedTime!.format(context)}"
-                            : "Time: Not set",
+              child: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextField(
+                      controller: titleController,
+                      decoration: const InputDecoration(
+                        labelText: "Task Title",
                       ),
-                      const Spacer(),
-                      TextButton(
-                        onPressed: () async {
-                          final picked = await showTimePicker(
-                            context: context,
-                            initialTime: TimeOfDay.now(),
+                    ),
+                    const SizedBox(height: 8),
+                    TextField(
+                      controller: descriptionController,
+                      decoration: const InputDecoration(
+                        labelText: "Description",
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+
+                    // Time picker
+                    Row(
+                      children: [
+                        Text(
+                          selectedTime != null
+                              ? "Time: ${selectedTime!.format(context)}"
+                              : "Time: Not set",
+                        ),
+                        const Spacer(),
+                        TextButton(
+                          onPressed: () async {
+                            final picked = await showTimePicker(
+                              context: context,
+                              initialTime: TimeOfDay.now(),
+                            );
+                            if (picked != null) {
+                              setState(() {
+                                selectedTime = picked;
+                              });
+                            }
+                          },
+                          child: const Text("Pick Time"),
+                        ),
+                      ],
+                    ),
+
+                    const SizedBox(height: 12),
+
+                    // Caregiver: show dropdown
+                    if (user.isCaregiver)
+                      DropdownButtonFormField<int>(
+                        decoration: const InputDecoration(
+                          labelText: "Assign to Patient",
+                          border: OutlineInputBorder(),
+                        ),
+                        items: patients.map((p) {
+                          final patient = p['patient'];
+                          return DropdownMenuItem<int>(
+                            value: patient['id'],
+                            child: Text(
+                              "${patient['firstName']} ${patient['lastName']}",
+                            ),
                           );
-                          if (picked != null) {
-                            setState(() {
-                              selectedTime = picked;
-                            });
-                          }
+                        }).toList(),
+                        onChanged: (val) {
+                          setState(() {
+                            selectedPatientId = val;
+                          });
                         },
-                        child: const Text("Pick Time"),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 12),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
-                      TextButton(
-                        onPressed: () => Navigator.pop(context, false),
-                        child: const Text("Cancel"),
-                      ),
-                      ElevatedButton(
-                        onPressed: () => Navigator.pop(context, true),
-                        child: const Text("Save"),
-                      ),
-                    ],
-                  ),
-                ],
+                      )
+                    else
+                      Text("Assigned to: ${user.name}"),
+                    const SizedBox(height: 12),
+
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, false),
+                          child: const Text("Cancel"),
+                        ),
+                        ElevatedButton(
+                          onPressed: () {
+                            if (user.isCaregiver && selectedPatientId == null) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(
+                                  content: Text("Please select a patient"),
+                                ),
+                              );
+                              return;
+                            }
+                            Navigator.pop(context, true);
+                          },
+                          child: const Text("Save"),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -479,7 +530,8 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
 
     if (confirmed != true) return;
 
-    final patientId = user.id;
+    //Pick correct patientId
+    final patientId = user.isPatient ? user.id : selectedPatientId!;
 
     final newTaskJson = {
       'id': -1,
@@ -489,7 +541,6 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
       'timeOfDay': selectedTime != null
           ? '${selectedTime!.hour.toString().padLeft(2, '0')}:${selectedTime!.minute.toString().padLeft(2, '0')}'
           : null,
-      //For now this is ignored until the endpoint is updated
       'userId': patientId,
     };
 
@@ -498,7 +549,6 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         patientId,
         jsonEncode(newTaskJson),
       );
-      //Add message sent if good response then make sure the class updates from DB
       if (response.statusCode == 200 || response.statusCode == 201) {
         await _loadTasksFromDb();
         if (!mounted) return;
@@ -615,7 +665,6 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
                         labelText: "Assign to Patient",
                         border: OutlineInputBorder(),
                       ),
-                      //This portion of the create menu is blocked by limitations of the endpoint for now.
                       initialValue: selectedPatientId,
                       items: patients.map((p) {
                         return DropdownMenuItem<int>(
@@ -678,7 +727,10 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     );
 
     try {
-      final response = await ApiService.editTask(task.id, updatedTask.toJson());
+      final response = await ApiService.editTaskV2(
+        task.id,
+        updatedTask.toJson(),
+      );
 
       //Edit message sent if good response then make sure the class updates from DB
       if (response.statusCode == 200) {
@@ -730,7 +782,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
     if (confirmed != true) return;
 
     try {
-      final response = await ApiService.deleteTask(task.id);
+      final response = await ApiService.deleteTaskV2(task.id);
       //Removal message sent if good response then make sure the class updates from DB
       if (response.statusCode == 200 || response.statusCode == 204) {
         await _loadTasksFromDb();

--- a/careconnect2025/frontend/lib/services/api_service.dart
+++ b/careconnect2025/frontend/lib/services/api_service.dart
@@ -1,15 +1,17 @@
 import 'dart:convert';
 import 'dart:io';
-import 'package:http/http.dart' as httpClient;
-
-import '../config/env_constant.dart';
-import 'package:http/http.dart' as http;
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:path/path.dart' as path;
-import 'auth_token_manager.dart';
 import 'dart:typed_data';
 
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/http.dart' as httpClient;
+import 'package:path/path.dart' as path;
+
+import '../config/env_constant.dart';
+import 'auth_token_manager.dart';
+
 class ApiConstants {
+  //V1 endpoints
   static final String _host = getBackendBaseUrl();
   static final String auth = '$_host/v1/api/auth';
   static final String feed = '$_host/v1/api/feed';
@@ -25,6 +27,10 @@ class ApiConstants {
   static final String connectionRequests = '$_host/v1/api/connection-requests';
   static final String subscriptions = '$_host/v1/api/subscriptions';
   static final String tasks = '$_host/v1/api/tasks';
+
+  //V2 endpoints
+  static final String baseUrlV2 = '$_host/v2/api/';
+  static final String tasksV2 = '$_host/v2/api/tasks';
 
   // AI Services endpoints
   static final String aiChat = '$_host/v1/api/ai-chat';
@@ -1073,6 +1079,62 @@ class ApiService {
           Uri.parse('${ApiConstants.tasks}/patient/$patientId'),
           headers: headers,
           body: task,
+        )
+        .timeout(const Duration(seconds: 30));
+  }
+  // ========================
+  // TASK METHODS (V2)
+  // ========================
+
+  // Get patient tasks (v2)
+  static Future<http.Response> getPatientTasksV2(int patientId) async {
+    final headers = await AuthTokenManager.getAuthHeaders();
+    return await _httpClient
+        .get(
+          Uri.parse('${ApiConstants.tasksV2}/patient/$patientId'),
+          headers: headers,
+        )
+        .timeout(const Duration(seconds: 30));
+  }
+
+  // Delete a task by task ID (v2)
+  static Future<http.Response> deleteTaskV2(int taskId) async {
+    final headers = await AuthTokenManager.getAuthHeaders();
+    return await _httpClient
+        .delete(Uri.parse('${ApiConstants.tasksV2}/$taskId'), headers: headers)
+        .timeout(const Duration(seconds: 30));
+  }
+
+  // Edit a task by task ID (v2)
+  static Future<http.Response> editTaskV2(
+    int taskId,
+    Map<String, dynamic> taskData,
+  ) async {
+    final headers = await AuthTokenManager.getAuthHeaders();
+    headers['Content-Type'] = 'application/json';
+
+    return await _httpClient
+        .put(
+          Uri.parse('${ApiConstants.tasksV2}/$taskId'),
+          headers: headers,
+          body: jsonEncode(taskData),
+        )
+        .timeout(const Duration(seconds: 30));
+  }
+
+  // Create a task (v2)
+  static Future<http.Response> createTaskV2(
+    int patientId,
+    String taskJson,
+  ) async {
+    final headers = await AuthTokenManager.getAuthHeaders();
+    headers['Content-Type'] = 'application/json';
+
+    return await _httpClient
+        .post(
+          Uri.parse('${ApiConstants.tasksV2}/patient/$patientId'),
+          headers: headers,
+          body: taskJson,
         )
         .timeout(const Duration(seconds: 30));
   }

--- a/careconnect2025/frontend/lib/services/api_service.dart
+++ b/careconnect2025/frontend/lib/services/api_service.dart
@@ -1139,6 +1139,14 @@ class ApiService {
         .timeout(const Duration(seconds: 30));
   }
 
+  // Get a single task by ID (v2)
+  static Future<http.Response> getTaskByIdV2(int taskId) async {
+    final headers = await AuthTokenManager.getAuthHeaders();
+    return await _httpClient
+        .get(Uri.parse('${ApiConstants.tasksV2}/$taskId'), headers: headers)
+        .timeout(const Duration(seconds: 30));
+  }
+
   static Future<Map<String, dynamic>?> getEnhancedPatientProfile(
     int patientId,
   ) async {

--- a/careconnect2025/frontend/lib/widgets/common_drawer.dart
+++ b/careconnect2025/frontend/lib/widgets/common_drawer.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
-import '../providers/user_provider.dart';
+
 import '../config/router/app_router.dart';
-import 'theme_toggle_switch.dart';
+import '../providers/user_provider.dart';
 import '../services/api_service.dart';
+import 'theme_toggle_switch.dart';
 
 class CommonDrawer extends StatefulWidget {
   final String currentRoute;
@@ -187,6 +188,15 @@ class _CommonDrawerState extends State<CommonDrawer> {
               Navigator.pop(context);
               navigateToDashboard(context);
             },
+          ),
+
+          // Calendar Assistant - always visible
+          _buildDrawerItem(
+            context,
+            icon: Icons.calendar_month,
+            title: 'Calendar Assistant',
+            route: '/calendar',
+            isActive: widget.currentRoute == '/calendar',
           ),
 
           // Core Features (reordered logically)

--- a/careconnect2025/frontend/pubspec.yaml
+++ b/careconnect2025/frontend/pubspec.yaml
@@ -118,6 +118,10 @@ dependencies:
     sdk: flutter
 
   web: ^1.1.0
+
+  #The following is needed as the calendar for the Calendar Assisstant feature
+  table_calendar: ^3.2.0
+  
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### General Work
In the branch being merged the first iteration of the Calendar assistant is established. This also includes V2 of the task endpoint. And I slightly change in the task DB that will cause no backwards compatibility issues but may require reset of the the DB before use depending on if you are working form older existing versions of a DB store. 

### Branch achieves:
- Calendar assistant with task system support. But not notifications support.
- New V2 of Task Endpoint
  - allows access to task patient information
  -  removes task model code not used or needed from legacy
  - int -> Integer of interval and doCount fields in Task Table of DB. Needed the clear and nullable ability for Calendar Assistant features. Other older uses of the task system should not be harmed by this change, if a DB reset is completed. 
- Calendar
  - Month View
  - CRUD Task abilities
  - Allows care givers to make tasks and assign them to patients 
  - Filter logic for task type and if the user is a care giver by patients
  - List breakdown of selected day
  - CRUD of reoccurring serries of tasks
  - Today button to align focus on calendar back to current day regardless what time was displayed.

### GitHub Issues
The Following GitHub issues are addressed:
- resolves #294 
- resolves #295 
- resolves #276 
- resolves #278 
- resolves #281 

### NOTE
Please note that due to my IDE the comparisons from commits may seem unexpected. The IDE automatically removed not needed imports and also rearranged them.