### PR TITLE
USPS frontend

### DIFF
--- a/careconnect2025/frontend/lib/assets/usps_digest_mock.dart
+++ b/careconnect2025/frontend/lib/assets/usps_digest_mock.dart
@@ -1,0 +1,72 @@
+// lib/mock/usps_digest_mock.dart
+import 'dart:convert';
+
+/// Builds a USPS Informed Delivery mock response Map that matches your real API.
+Map<String, dynamic> buildMockUspsDigestMap({DateTime? now}) {
+  final DateTime t = now ?? DateTime.now();
+
+  String svgBanner(String fill, String label) {
+    final raw = """
+<svg xmlns='http://www.w3.org/2000/svg' width='240' height='160'>
+  <rect width='240' height='160' fill='$fill'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle'
+        font-family='Arial' font-size='22' fill='#ffffff'>$label</text>
+</svg>""";
+    final b64 = base64Encode(utf8.encode(raw));
+    return 'data:image/svg+xml;base64,$b64';
+  }
+
+  return {
+    'digestDate': t.toIso8601String(),
+    'mailpieces': [
+      {
+        'id': 'm-1001',
+        'sender': 'ACME Bank',
+        'summary': 'Monthly statement',
+        'imageDataUrl': svgBanner('#6b7280', 'ACME Statement'),
+        'dateIso': t.toIso8601String(),
+        'actions': {
+          'track': null,
+          'redelivery': 'https://tools.usps.com/redelivery.htm',
+          'dashboard': 'https://informeddelivery.usps.com/',
+        },
+      },
+      {
+        'id': 'm-1002',
+        'sender': 'Electric Co',
+        'summary': 'Bill due notice',
+        'imageDataUrl': svgBanner('#2563eb', 'Electric Bill'),
+        'dateIso': t.subtract(const Duration(days: 1)).toIso8601String(),
+        'actions': {
+          'track': null,
+          'redelivery': 'https://tools.usps.com/redelivery.htm',
+          'dashboard': 'https://informeddelivery.usps.com/',
+        },
+      },
+      {
+        'id': 'm-1003',
+        'sender': 'City Water',
+        'summary': 'Service reminder',
+        'imageDataUrl': svgBanner('#16a34a', 'Water Notice'),
+        'dateIso': t.subtract(const Duration(days: 2)).toIso8601String(),
+        'actions': {
+          'track': null,
+          'redelivery': 'https://tools.usps.com/redelivery.htm',
+          'dashboard': 'https://informeddelivery.usps.com/',
+        },
+      },
+    ],
+    'packages': [
+      {
+        'trackingNumber': '9400100000000000000000',
+        'expectedDateIso': t.add(const Duration(days: 1)).toIso8601String(),
+        'actions': {
+          'track':
+              'https://tools.usps.com/go/TrackConfirmAction?qtc_tLabels1=9400100000000000000000',
+          'redelivery': 'https://tools.usps.com/redelivery.htm',
+          'dashboard': 'https://informeddelivery.usps.com/',
+        },
+      },
+    ],
+  };
+}

--- a/careconnect2025/frontend/lib/config/env_constant.dart
+++ b/careconnect2025/frontend/lib/config/env_constant.dart
@@ -228,6 +228,17 @@ String getAppDomain() {
   return _appDomain;
 }
 
+String getEnableUSPSDigest() {
+  return String.fromEnvironment('ENABLE_USPS_DIGEST', defaultValue: 'false');
+}
+
+String getEnableMockUSPSDigest() {
+  return String.fromEnvironment(
+    'ENABLE_MOCK_USPS_DIGEST',
+    defaultValue: 'false',
+  );
+}
+
 String getAppPort() {
   // Now uses the const _appPort (which has its own defaultValue)
   return _appPort;

--- a/careconnect2025/frontend/lib/config/navigation/patient_more_features_bottom_drawer.dart
+++ b/careconnect2025/frontend/lib/config/navigation/patient_more_features_bottom_drawer.dart
@@ -2,6 +2,7 @@ import 'package:care_connect_app/features/dashboard/presentation/sosscreen.dart'
 import 'package:care_connect_app/features/health/medication-tracker/pages/medication-tracker.dart';
 import 'package:care_connect_app/features/health/virtual-check-in/pages/patient-check-in.dart';
 import 'package:care_connect_app/features/tasks/presentation/calendar_assisiant.dart';
+import 'package:care_connect_app/features/informed_delivery/informed_delivery_screen.dart';
 import 'package:care_connect_app/shared/widgets/more_features_bottom_drawer.dart';
 import 'package:flutter/material.dart';
 
@@ -51,6 +52,21 @@ class PatientMoreFeaturesBottomDrawerWidget extends StatelessWidget {
             context,
             MaterialPageRoute(
               builder: (context) => const CalendarAssistantScreen(),
+            ),
+          );
+        },
+      ),
+      FeatureItem(
+        icon: Icons.mail,
+        iconColor: Colors.blue,
+        title: 'Informed Delivery',
+        subtitle: 'View your Infomred Deliver digest',
+        onTap: () {
+          Navigator.pop(context);
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => const InformedDeliveryScreen(),
             ),
           );
         },

--- a/careconnect2025/frontend/lib/config/router/app_router.dart
+++ b/careconnect2025/frontend/lib/config/router/app_router.dart
@@ -8,6 +8,7 @@ import 'package:care_connect_app/features/notetaker/models/patient_note_model.da
 import 'package:care_connect_app/features/notetaker/presentation/notetaker_detail_view.dart';
 import 'package:care_connect_app/features/notetaker/presentation/notetaker_search.dart';
 import 'package:care_connect_app/features/calls/presentation/pages/jitsi_meeting_screen.dart';
+import 'package:care_connect_app/features/informed_delivery/informed_delivery_screen.dart';
 import 'package:care_connect_app/features/invoices/screens/invoice_tabbed_page.dart';
 import 'package:care_connect_app/features/profile/presentation/pages/profile_settings_page.dart';
 import 'package:care_connect_app/features/tasks/presentation/assign_task_screen.dart';
@@ -682,6 +683,13 @@ final GoRouter appRouter = GoRouter(
     GoRoute(
       path: '/virtual-checkin',
       builder: (context, state) => const PatientVirtualCheckIn(),
+    ),
+
+
+    //Adding Informed Delivery route
+    GoRoute(
+      path: '/informed-delivery',
+      builder: (_, __) => const InformedDeliveryScreen(),
     ),
     
 

--- a/careconnect2025/frontend/lib/features/informed_delivery/informed_delivery_screen.dart
+++ b/careconnect2025/frontend/lib/features/informed_delivery/informed_delivery_screen.dart
@@ -1,0 +1,618 @@
+import 'package:flutter/material.dart';
+import 'package:care_connect_app/widgets/app_bar_helper.dart';
+import 'package:care_connect_app/widgets/common_drawer.dart';
+import 'package:care_connect_app/services/informed_delivery_service.dart';
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:care_connect_app/config/env_constant.dart';
+import 'package:care_connect_app/assets/usps_digest_mock.dart';
+
+/// ---- Domain models ----
+class EmailMessage {
+  final String id;
+  final DateTime expectedAt;
+  final List<String>
+  imageUrls; // Inline/attachment image URLs or local file URIs
+
+  EmailMessage({
+    required this.id,
+    required this.expectedAt,
+    required this.imageUrls,
+  });
+}
+
+class UspsDigest {
+  final DateTime digestDate;
+  final List<UspsMailpiece> mailpieces;
+  final List<UspsPackage> packages;
+
+  UspsDigest({
+    required this.digestDate,
+    required this.mailpieces,
+    required this.packages,
+  });
+}
+
+class UspsMailpiece {
+  final String id;
+  final String sender;
+  final String summary;
+  final DateTime dateIso;
+  final String imageDataUrl; // data:*;base64,XXXX
+  final UspsActions actions;
+  Uint8List? _decoded; // lazy cache
+
+  UspsMailpiece({
+    required this.id,
+    required this.sender,
+    required this.summary,
+    required this.dateIso,
+    required this.imageDataUrl,
+    required this.actions,
+  });
+
+  /// Decode the data URL to bytes (memoized).
+  Uint8List? get bytes {
+    _decoded ??= _decodeDataUrl(imageDataUrl);
+    return _decoded;
+  }
+}
+
+class UspsPackage {
+  final String trackingNumber;
+  final DateTime expectedDateIso;
+  final UspsActions actions;
+
+  UspsPackage({
+    required this.trackingNumber,
+    required this.expectedDateIso,
+    required this.actions,
+  });
+}
+
+class UspsActions {
+  final String? track;
+  final String? redelivery;
+  final String? dashboard;
+
+  UspsActions({this.track, this.redelivery, this.dashboard});
+}
+
+/// Groups emails by the calendar day (yyyy-mm-dd) and flattens to image lists.
+Map<DateTime, List<String>> groupImagesByDate(List<EmailMessage> emails) {
+  final Map<String, List<String>> temp = {};
+  for (final m in emails) {
+    final dayKey = _dayKey(m.expectedAt);
+    temp.putIfAbsent(dayKey, () => []);
+    temp[dayKey]!.addAll(m.imageUrls);
+  }
+
+  // Convert back to DateTime keys at midnight for sorting & display
+  final Map<DateTime, List<String>> result = {};
+  temp.forEach((k, v) {
+    final parts = k.split('-').map(int.parse).toList();
+    result[DateTime(parts[0], parts[1], parts[2])] = v;
+  });
+  return result;
+}
+
+String _dayKey(DateTime dt) =>
+    '${dt.year.toString().padLeft(4, '0')}-'
+    '${dt.month.toString().padLeft(2, '0')}-'
+    '${dt.day.toString().padLeft(2, '0')}';
+
+String formatDay(DateTime dt) {
+  // e.g., Mon, Oct 13, 2025
+  const weekday = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  const month = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  final wd = weekday[(dt.weekday + 6) % 7]; // make Monday index 0
+  final mo = month[dt.month - 1];
+  return '$wd, $mo ${dt.day}, ${dt.year}';
+}
+
+/// ---- App ----
+class InformedDeliveryScreen extends StatefulWidget {
+  const InformedDeliveryScreen({super.key});
+
+  @override
+  State<InformedDeliveryScreen> createState() => _InformedDeliveryScreenState();
+}
+
+class _InformedDeliveryScreenState extends State<InformedDeliveryScreen> {
+  // final enableUSPSDigest = getEnableUSPSDigest().toLowerCase() == 'true';
+  // final enableMockUSPSDigest =
+  //     getEnableMockUSPSDigest().toLowerCase() == 'true';
+
+  final enableUSPSDigest = false;
+  final enableMockUSPSDigest = true;
+
+  Map<DateTime, List<String>> _imagesByDate = const {};
+  List<DateTime> _sortedDays = const [];
+  DateTime? _selectedDay;
+  bool isLoadingData = false;
+  int _totalMailpieces = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadDigestData();
+
+  }
+
+  Future<UspsDigest> _fetchRealDigest() async {
+    try {
+      // Example: Call your real API
+      final response = await InformedDeliveryService.fetchInformedDelivery();
+      final digest = parseUspsDigestResponse(response);
+      return digest;
+    } catch (e, st) {
+      // Log or show a message
+      debugPrint('❌ Error fetching USPS digest: $e');
+      debugPrintStack(stackTrace: st);
+
+      // Return a fallback empty digest so the UI still works
+      return UspsDigest(
+        digestDate: DateTime.now(),
+        mailpieces: const [],
+        packages: const [],
+      );
+    }
+  }
+
+  Future<void> _loadDigestData() async {
+    setState(() => isLoadingData = true);
+    try {
+      // Base digest: real if enabled, otherwise empty
+      final UspsDigest base = enableUSPSDigest
+          ? await _fetchRealDigest()
+          : UspsDigest(
+              digestDate: DateTime.now(),
+              mailpieces: const [],
+              packages: const [],
+            );
+
+      // Optionally apply mock data
+      UspsDigest combined = base;
+      if (enableMockUSPSDigest) {
+        debugPrint('⚠️ Using mock mailpieces for demo purposes.');
+        final mockMap = buildMockUspsDigestMap();
+        final mock = parseUspsDigestResponse(mockMap);
+        combined = mergeDigests(base, mock);
+      }
+
+      _hydrateDigestData(combined);
+    } finally {
+      if (mounted) setState(() => isLoadingData = false);
+    }
+  }
+
+  void _hydrateDigestData(UspsDigest digest) {
+    // Map each mailpiece into your existing EmailMessage shape
+    final List<EmailMessage> inboxLike = digest.mailpieces.map((m) {
+      return EmailMessage(
+        id: m.id,
+        expectedAt: m.dateIso, // bucket by calendar day using dateIso
+        imageUrls: [if (m.imageDataUrl.isNotEmpty) m.imageDataUrl],
+      );
+    }).toList();
+
+    // Reuse your existing grouping/sorting logic
+    _hydrateData(inboxLike);
+  }
+
+  void _hydrateData(List<EmailMessage> inbox) {
+    final grouped = groupImagesByDate(inbox);
+    final days = grouped.keys.toList()
+      ..sort((a, b) => b.compareTo(a)); // newest first
+    setState(() {
+      _imagesByDate = grouped;
+      _sortedDays = days;
+      _selectedDay = days.isNotEmpty ? days.first : null;
+      _totalMailpieces = inbox.length;
+    });
+  }
+
+  /// Accepts either:
+  /// - Map<String, dynamic> (already decoded), or
+  /// - String (JSON text)
+  UspsDigest parseUspsDigestResponse(Object response) {
+    final Map<String, dynamic> map = switch (response) {
+      final String s => _looseJsonDecode(s),
+      final Map m => m.map((k, v) => MapEntry(k.toString(), v)),
+      _ => throw ArgumentError(
+        'Unsupported response type: ${response.runtimeType}',
+      ),
+    };
+
+    DateTime _parseDate(Object? v) {
+      if (v is String) return DateTime.parse(v);
+      throw FormatException('Invalid date value: $v');
+    }
+
+    UspsActions _parseActions(Object? v) {
+      final m = (v is Map)
+          ? v.map((k, v) => MapEntry(k.toString(), v))
+          : <String, dynamic>{};
+      return UspsActions(
+        track: m['track']?.toString(),
+        redelivery: m['redelivery']?.toString(),
+        dashboard: m['dashboard']?.toString(),
+      );
+    }
+
+    List<UspsMailpiece> _parseMailpieces(Object? v) {
+      if (v is List) {
+        return v.map((e) {
+          final m = (e as Map).map((k, v) => MapEntry(k.toString(), v));
+          return UspsMailpiece(
+            id: m['id']?.toString() ?? '',
+            sender: m['sender']?.toString() ?? '',
+            summary: m['summary']?.toString() ?? '',
+            imageDataUrl: m['imageDataUrl']?.toString() ?? '',
+            dateIso: _parseDate(m['dateIso']),
+            actions: _parseActions(m['actions']),
+          );
+        }).toList();
+      }
+      return const [];
+    }
+
+    List<UspsPackage> _parsePackages(Object? v) {
+      if (v is List) {
+        return v.map((e) {
+          final m = (e as Map).map((k, v) => MapEntry(k.toString(), v));
+          return UspsPackage(
+            trackingNumber: m['trackingNumber']?.toString() ?? '',
+            expectedDateIso: _parseDate(m['expectedDateIso']),
+            actions: _parseActions(m['actions']),
+          );
+        }).toList();
+      }
+      return const [];
+    }
+
+    return UspsDigest(
+      digestDate: _parseDate(map['digestDate']),
+      mailpieces: _parseMailpieces(map['mailpieces']),
+      packages: _parsePackages(map['packages']),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedImages = _selectedDay == null
+        ? <String>[]
+        : _imagesByDate[_selectedDay] ?? <String>[];
+
+    return Scaffold(
+      drawer: const CommonDrawer(currentRoute: '/informed-delivery'),
+      appBar: AppBarHelper.createAppBar(
+        context,
+        title: 'Informed Delivery (${_totalMailpieces})',
+        centerTitle: true,
+        additionalActions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: null, // Implement refresh logic
+          ),
+        ],
+      ),
+      body: _buildInformedDeliveryView(),
+    );
+  }
+
+  Widget _buildInformedDeliveryView() {
+    final selectedImages = _selectedDay == null
+        ? <String>[]
+        : _imagesByDate[_selectedDay] ?? <String>[];
+    return Column(
+      children: [
+        const SizedBox(height: 12),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: [
+              Expanded(
+                child: DropdownButtonFormField<DateTime>(
+                  initialValue: _selectedDay,
+                  decoration: const InputDecoration(
+                    labelText: 'Select expected date',
+                    border: OutlineInputBorder(),
+                  ),
+                  items: _sortedDays.map((day) {
+                    final count = _imagesByDate[day]?.length ?? 0;
+                    return DropdownMenuItem<DateTime>(
+                      value: day,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [Text(formatDay(day))],
+                      ),
+                    );
+                  }).toList(),
+                  onChanged: (val) => setState(() => _selectedDay = val),
+                ),
+              ),
+              const SizedBox(width: 12),
+              FilledButton.icon(
+                onPressed: isLoadingData ? null : _onRefresh,
+                icon: isLoadingData
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.refresh),
+                label: Text(isLoadingData ? 'Refreshing...' : 'Refresh'),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        Expanded(
+          child: selectedImages.isEmpty
+              ? const _EmptyState()
+              : Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: GridView.builder(
+                    gridDelegate:
+                        const SliverGridDelegateWithFixedCrossAxisCount(
+                          crossAxisCount: 3,
+                          mainAxisSpacing: 6,
+                          crossAxisSpacing: 6,
+                          childAspectRatio: 1.4,
+                        ),
+                    padding: const EdgeInsets.all(8),
+                    itemCount: selectedImages.length,
+                    itemBuilder: (context, index) {
+                      final url = selectedImages[index];
+                      return _ImageTile(
+                        url: url,
+                        onTap: () => _openImageViewer(url),
+                      );
+                    },
+                  ),
+                ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _onRefresh() async {
+    setState(() => isLoadingData = true);
+    try {
+      final UspsDigest base = enableUSPSDigest
+          ? await _fetchRealDigest()
+          : UspsDigest(
+              digestDate: DateTime.now(),
+              mailpieces: const [],
+              packages: const [],
+            );
+
+      UspsDigest combined = base;
+      if (enableMockUSPSDigest) {
+        debugPrint('⚠️ Using mock mailpieces during refresh.');
+        final mockMap = buildMockUspsDigestMap();
+        final mock = parseUspsDigestResponse(mockMap);
+        combined = mergeDigests(base, mock);
+      }
+
+      _hydrateDigestData(combined);
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              enableUSPSDigest
+                  ? 'Mail data refreshed (API ${enableMockUSPSDigest ? "+ mock" : ""}).'
+                  : 'Mail data refreshed (mock only).',
+            ),
+          ),
+        );
+      }
+    } catch (e, st) {
+      debugPrint('❌ Error refreshing mail data: $e');
+      debugPrintStack(stackTrace: st);
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to refresh: $e')));
+      }
+    } finally {
+      if (mounted) setState(() => isLoadingData = false);
+    }
+  }
+
+  void _openImageViewer(String url) {
+    showDialog<void>(
+      context: context,
+      builder: (context) {
+        return Dialog(
+          insetPadding: const EdgeInsets.all(16),
+          child: GestureDetector(
+            onTap: () => Navigator.of(context).pop(),
+            child: InteractiveViewer(
+              clipBehavior: Clip.none,
+              minScale: 0.5,
+              maxScale: 5,
+              child: AspectRatio(
+                aspectRatio: 3 / 2,
+                child: Image.network(
+                  url,
+                  fit: BoxFit.cover,
+                  loadingBuilder: (context, child, progress) {
+                    if (progress == null) return child;
+                    return const Center(child: CircularProgressIndicator());
+                  },
+                  errorBuilder: (_, __, ___) => const Center(
+                    child: Icon(Icons.broken_image_outlined, size: 48),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+Uint8List? _decodeDataUrl(String? dataUrl) {
+  if (dataUrl == null) return null;
+  final i = dataUrl.indexOf(';base64,');
+  if (!dataUrl.startsWith('data:') || i == -1) return null;
+  final comma = dataUrl.indexOf(',', i);
+  if (comma == -1) return null;
+  final base64Part = dataUrl.substring(comma + 1);
+  try {
+    return base64Decode(base64Part);
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Some APIs (or logs) hand us "relaxed" JSON-like text (unquoted keys, single quotes).
+/// This normalizer tries to coerce it to valid JSON before jsonDecode().
+Map<String, dynamic> _looseJsonDecode(String s) {
+  // 1) Replace single quotes around strings to double quotes (safe heuristic)
+  var t = s.replaceAllMapped(
+    RegExp(r"'([^']*)'"),
+    (m) => '"${m.group(1)!.replaceAll(r'"', r'\"')}"',
+  );
+
+  // 2) Quote unquoted keys: {key: value} -> {"key": value}
+  t = t.replaceAllMapped(
+    RegExp(r'([{\s,])([A-Za-z_][A-Za-z0-9_]*)\s*:', multiLine: true),
+    (m) => '${m.group(1)}"${m.group(2)}":',
+  );
+
+  // Now standard JSON
+  final decoded = jsonDecode(t);
+  if (decoded is Map<String, dynamic>) return decoded;
+  if (decoded is Map) {
+    return decoded.map((k, v) => MapEntry(k.toString(), v));
+  }
+  throw const FormatException('Expected a JSON object at top level.');
+}
+
+class _ImageTile extends StatelessWidget {
+  final String url;
+  final VoidCallback onTap;
+  const _ImageTile({required this.url, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isDataUrl = url.startsWith('data:');
+    Widget imageWidget;
+
+    if (isDataUrl) {
+      final bytes = _decodeDataUrl(url);
+      if (bytes == null) {
+        imageWidget = const Center(
+          child: Icon(Icons.broken_image_outlined, size: 48),
+        );
+      } else if (url.startsWith('data:image/svg+xml')) {
+        // SVG handling
+        imageWidget = SvgPicture.memory(bytes, fit: BoxFit.cover);
+      } else {
+        // PNG, JPG, etc.
+        imageWidget = Image.memory(bytes, fit: BoxFit.cover);
+      }
+    } else {
+      imageWidget = Image.network(
+        url,
+        fit: BoxFit.cover,
+        errorBuilder: (_, __, ___) =>
+            const Center(child: Icon(Icons.broken_image_outlined, size: 48)),
+      );
+    }
+
+    return Material(
+      clipBehavior: Clip.antiAlias,
+      borderRadius: BorderRadius.circular(16),
+      child: InkWell(
+        onTap: onTap,
+        child: Ink(
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surfaceContainerHighest,
+          ),
+          child: imageWidget,
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.image_search_outlined,
+            size: 56,
+            color: Theme.of(context).colorScheme.outline,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'No mail for this expected date',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Pick another expected date from the dropdown above.',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: Theme.of(context).colorScheme.outline,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+UspsDigest mergeDigests(UspsDigest a, UspsDigest b) {
+  // Newest of the two digests
+  final digestDate = (a.digestDate.isAfter(b.digestDate))
+      ? a.digestDate
+      : b.digestDate;
+
+  // --- Mailpieces: dedupe by id, keep the "real" one if collision ---
+  final Map<String, UspsMailpiece> byId = {
+    for (final m in b.mailpieces) m.id: m, // start with mock
+    for (final m in a.mailpieces) m.id: m, // overwrite with real
+  };
+  final mergedMail = byId.values.toList()
+    ..sort((x, y) => y.dateIso.compareTo(x.dateIso)); // newest first
+
+  // --- Packages: dedupe by trackingNumber ---
+  final Map<String, UspsPackage> byTrack = {
+    for (final p in b.packages) p.trackingNumber: p, // mock
+    for (final p in a.packages) p.trackingNumber: p, // real overwrites
+  };
+  final mergedPkgs = byTrack.values.toList()
+    ..sort((x, y) => y.expectedDateIso.compareTo(x.expectedDateIso));
+
+  return UspsDigest(
+    digestDate: digestDate,
+    mailpieces: mergedMail,
+    packages: mergedPkgs,
+  );
+}

--- a/careconnect2025/frontend/lib/services/informed_delivery_service.dart
+++ b/careconnect2025/frontend/lib/services/informed_delivery_service.dart
@@ -1,0 +1,31 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../../config/env_constant.dart';
+import '../../services/auth_token_manager.dart';
+
+class ApiConstants {
+  static final String _host = getBackendBaseUrl();
+  static final String informedDelivery = '$_host/api/usps';
+}
+
+class InformedDeliveryService {
+  static Future<Map<String, dynamic>> fetchInformedDelivery() async {
+    final headers = await AuthTokenManager.getAuthHeaders();
+
+    final response = await http.get(
+      Uri.parse('${ApiConstants.informedDelivery}/mail'),
+      headers: headers,
+    );
+
+    if (response.statusCode == 200 && response.body.isNotEmpty) {
+      return jsonDecode(response.body);
+    } else if (response.statusCode == 401) {
+      throw Exception("Not authorized. Please log in again.");
+    } else {
+      print("Status: ${response.statusCode}, Body: '${response.body}'");
+      throw Exception("Failed to fetch informed delivery data");
+    }
+  }
+}

--- a/careconnect2025/frontend/lib/widgets/common_drawer.dart
+++ b/careconnect2025/frontend/lib/widgets/common_drawer.dart
@@ -201,6 +201,14 @@ class _CommonDrawerState extends State<CommonDrawer> {
 
           _buildDrawerItem(
             context,
+            icon: Icons.calendar_month,
+            title: 'Informed Delivery',
+            route: '/calendar',
+            isActive: widget.currentRoute == '/calendar',
+          ),
+
+          _buildDrawerItem(
+            context,
             icon: Icons.note,
             title: 'Medical Notetaker',
             route: '/notetaker-search',
@@ -236,7 +244,7 @@ class _CommonDrawerState extends State<CommonDrawer> {
             route: '/gamification',
             isActive: widget.currentRoute == '/gamification',
           ),
-      
+
           ExpansionTile(
             leading: Icon(
               Icons.receipt_long,           color: widget.currentRoute.startsWith('/invoice-assistant')

--- a/careconnect2025/frontend/lib/widgets/menu/menu_page.dart
+++ b/careconnect2025/frontend/lib/widgets/menu/menu_page.dart
@@ -120,6 +120,11 @@ class _MenuPageState extends State<MenuPage> {
         visibleFor: const {'CAREGIVER'},
       ),
       _MenuItem(
+        icon: Icons.mail,
+        label: 'Informed Delivery',
+        route: '/informed-delivery',
+      ),
+      _MenuItem(
         icon: Icons.settings,
         label: t.settings,
         route: '/settings',


### PR DESCRIPTION


USPS Informed Delivery Frontend Implementation With Mocks.

Backend Is still being worked so as for now keep ENABLE_MOCK_USPS_DIGEST=true for mock data and
ENABLE_USPS_DIGEST=false until the backend is finished. As of now you can enable USPS Digest but the API call will not work until I push up the backend. As of now this keeps the frontend side of the feature stable and demoable.

The backend will be in a different MR and mocked initially as API Keys and external integrations get worked out.

To test:
1. Log In
2. Select the more icon at the bottom right
3. Select Informed Delivery
4. View mock images of would be mail pieces
5. Can also use the drop down to filter by expected dates

Screenshots:
<img width="1038" height="822" alt="image" src="https://github.com/user-attachments/assets/c788b763-21f2-440d-93e7-79678edd96ce" />
