### PR TITLE
Fix: Add /v1/api/emergency to JWT authentication bypass list

### DIFF
--- a/careconnect2025/backend/core/src/main/java/com/careconnect/security/JwtAuthenticationFilter.java
+++ b/careconnect2025/backend/core/src/main/java/com/careconnect/security/JwtAuthenticationFilter.java
@@ -43,7 +43,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         "/v1/api/test",
         "/v1/api/caregivers",
         "/v1/api/subscriptions",
-        "/v1/api/email-test"
+        "/v1/api/email-test",
+        "/v1/api/emergency"
     );
 
     private final JwtTokenProvider jwt;


### PR DESCRIPTION
## Summary
- Add `/v1/api/emergency` endpoint to the JWT authentication bypass list in `JwtAuthenticationFilter`

## Changes Made
- Updated `EXCLUDED_PATHS` list in `JwtAuthenticationFilter.java` to include `/v1/api/emergency`
- This allows emergency-related requests to bypass JWT authentication for better accessibility

## Test Plan
- [x] Emergency endpoints can be accessed without JWT token
- [x] Other protected endpoints still require authentication
- [x] No regression in existing authentication flow