### PR TITLE
591 mlord cal feedback fixes

### DIFF
--- a/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
@@ -664,32 +664,47 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
 
               const SizedBox(height: 16),
 
-              // Task list changes depending on view
+              // ------------------
+              // Task list section (scrollable)
+              // ------------------
               if (_selectedDay != null)
-                _currentView == CalendarViewType.week
-                    ? TaskListWeek(
-                        events: _eventController.events.where((e) {
-                          final weekStart = TaskUtils.getStartOfWeek(
-                            _selectedDay!,
-                          );
-                          final weekEnd = weekStart.add(
-                            const Duration(days: 7),
-                          );
-                          return e.date.isAfter(
-                                weekStart.subtract(const Duration(seconds: 1)),
-                              ) &&
-                              e.date.isBefore(weekEnd);
-                        }).toList(),
-                        patientNames: patientNames,
-                        onEdit: _editTask,
-                        onDelete: _removeTask,
-                      )
-                    : TaskListDay(
-                        events: _eventController.getEventsOnDay(_selectedDay!),
-                        patientNames: patientNames,
-                        onEdit: _editTask,
-                        onDelete: _removeTask,
-                      ),
+                Column(
+                  children: [
+                    const Divider(thickness: 1),
+                    SizedBox(
+                      // adjust this to control how tall the list area is
+                      height: MediaQuery.of(context).size.height * 0.25,
+                      child: _currentView == CalendarViewType.week
+                          ? TaskListWeek(
+                              events: _eventController.events.where((e) {
+                                final weekStart = TaskUtils.getStartOfWeek(
+                                  _selectedDay!,
+                                );
+                                final weekEnd = weekStart.add(
+                                  const Duration(days: 7),
+                                );
+                                return e.date.isAfter(
+                                      weekStart.subtract(
+                                        const Duration(seconds: 1),
+                                      ),
+                                    ) &&
+                                    e.date.isBefore(weekEnd);
+                              }).toList(),
+                              patientNames: patientNames,
+                              onEdit: _editTask,
+                              onDelete: _removeTask,
+                            )
+                          : TaskListDay(
+                              events: _eventController.getEventsOnDay(
+                                _selectedDay!,
+                              ),
+                              patientNames: patientNames,
+                              onEdit: _editTask,
+                              onDelete: _removeTask,
+                            ),
+                    ),
+                  ],
+                ),
             ],
           ),
         ),

--- a/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
@@ -16,6 +16,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
+import 'widgets/add_task_button.dart';
 import 'widgets/calendar_cell.dart';
 import 'widgets/event_tile.dart';
 import 'widgets/filters_panel.dart';
@@ -244,7 +245,6 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
         body: const Center(child: CircularProgressIndicator()),
       );
     }
-
     return CalendarControllerProvider<Task>(
       controller: _eventController,
       child: Scaffold(
@@ -253,14 +253,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
           context,
           title: 'Calendar Assistant',
           additionalActions: [
-            TextButton.icon(
-              icon: const Icon(Icons.add, color: Colors.white),
-              label: const Text(
-                "Add Task",
-                style: TextStyle(color: Colors.white),
-              ),
-              onPressed: _addTask,
-            ),
+            AddTaskButton(onPressed: _addTask),
             ImportIcsButton(
               onTasksImported: _loadTasksFromDb,
               patientNames: patientNames, //refresh calendar after import

--- a/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
@@ -673,7 +673,7 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
                     const Divider(thickness: 1),
                     SizedBox(
                       // adjust this to control how tall the list area is
-                      height: MediaQuery.of(context).size.height * 0.25,
+                      height: MediaQuery.of(context).size.height * 0.20,
                       child: _currentView == CalendarViewType.week
                           ? TaskListWeek(
                               events: _eventController.events.where((e) {

--- a/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/calendar_assisiant.dart
@@ -13,6 +13,7 @@ import 'package:care_connect_app/services/api_service.dart';
 import 'package:care_connect_app/widgets/app_bar_helper.dart';
 import 'package:care_connect_app/widgets/common_drawer.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 import 'widgets/calendar_cell.dart';
@@ -411,6 +412,46 @@ class _CalendarAssistantScreenState extends State<CalendarAssistantScreen> {
                                 color: theme.colorScheme.onSurface,
                               ),
                             ),
+                            headerBuilder: (date) {
+                              final formatted = DateFormat(
+                                'MMM yyyy',
+                              ).format(date);
+
+                              return Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  // Left arrow (previous month)
+                                  IconButton(
+                                    icon: const Icon(Icons.chevron_left),
+                                    color: theme.colorScheme.onSurface,
+                                    onPressed: () {
+                                      _monthKey.currentState?.previousPage();
+                                    },
+                                  ),
+
+                                  // Month title
+                                  Text(
+                                    formatted,
+                                    style: theme.textTheme.titleMedium
+                                        ?.copyWith(
+                                          color: theme.colorScheme.onSurface,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                  ),
+
+                                  // Right arrow (next month)
+                                  IconButton(
+                                    icon: const Icon(Icons.chevron_right),
+                                    color: theme.colorScheme.onSurface,
+                                    onPressed: () {
+                                      _monthKey.currentState?.nextPage();
+                                    },
+                                  ),
+                                ],
+                              );
+                            },
+
                             weekDayBuilder: (day) {
                               final labels = [
                                 "M",

--- a/careconnect2025/frontend/lib/features/tasks/presentation/widgets/add_task_button.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/widgets/add_task_button.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+/// A responsive "Add Task" button.
+/// - Shows a full [ElevatedButton.icon] on wide screens.
+/// - Shows an icon-only [IconButton] on compact screens.
+/// - Automatically adapts to theme colors (light/dark).
+class AddTaskButton extends StatelessWidget {
+  final VoidCallback onPressed;
+
+  const AddTaskButton({super.key, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    final isCompact = MediaQuery.sizeOf(context).width < 500;
+
+    if (isCompact) {
+      // Compact icon-only button for phones
+      return IconButton(
+        tooltip: 'Add Task',
+        icon: const Icon(Icons.add),
+        onPressed: onPressed,
+      );
+    }
+
+    // Full labeled button for larger screens
+    return ElevatedButton.icon(
+      onPressed: onPressed,
+      icon: const Icon(Icons.add, size: 18),
+      label: const Text('Add Task'),
+      style: ElevatedButton.styleFrom(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        textStyle: const TextStyle(fontSize: 14),
+      ),
+    );
+  }
+}

--- a/careconnect2025/frontend/lib/features/tasks/presentation/widgets/import_ics_button.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/widgets/import_ics_button.dart
@@ -297,10 +297,26 @@ class _ImportIcsButtonState extends State<ImportIcsButton> {
 
   @override
   Widget build(BuildContext context) {
+    final isCompact = MediaQuery.of(context).size.width < 500;
+
+    if (isCompact) {
+      // Compact version: icon-only
+      return IconButton(
+        tooltip: 'Import ICS',
+        icon: const Icon(Icons.file_upload),
+        onPressed: _openDialog,
+      );
+    }
+
+    // Default (wide) version: full labeled button
     return ElevatedButton.icon(
       onPressed: _openDialog,
       icon: const Icon(Icons.file_upload),
       label: const Text("Import ICS"),
+      style: ElevatedButton.styleFrom(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        textStyle: const TextStyle(fontSize: 14),
+      ),
     );
   }
 

--- a/careconnect2025/frontend/lib/features/tasks/presentation/widgets/task_form_dialog.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/widgets/task_form_dialog.dart
@@ -363,6 +363,35 @@ class _TaskFormDialogState extends State<TaskFormDialog> {
                 ),
 
                 const SizedBox(height: 16),
+                // ---- Date picker (only for single, nonrecurring tasks) ----
+                if (!isRecurring) ...[
+                  Row(
+                    children: [
+                      const Text("Date: "),
+                      Text(
+                        startDate != null
+                            ? "${startDate!.month}/${startDate!.day}/${startDate!.year}"
+                            : "Not set",
+                      ),
+                      const Spacer(),
+                      ElevatedButton(
+                        onPressed: () async {
+                          final picked = await showDatePicker(
+                            context: context,
+                            initialDate: startDate ?? DateTime.now(),
+                            firstDate: DateTime(2020),
+                            lastDate: DateTime(2100),
+                          );
+                          if (picked != null) {
+                            setState(() => startDate = picked);
+                          }
+                        },
+                        child: const Text("Pick Date"),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                ],
 
                 // ---- Time picker ----
                 Row(

--- a/careconnect2025/frontend/lib/features/tasks/presentation/widgets/task_list_day.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/widgets/task_list_day.dart
@@ -68,8 +68,13 @@ class TaskListDay extends StatelessWidget {
         return a.name.compareTo(b.name);
       });
 
-    return Column(
-      children: tasks.map((task) {
+    return ListView.builder(
+      shrinkWrap: true,
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.only(bottom: 16),
+      itemCount: tasks.length,
+      itemBuilder: (context, index) {
+        final task = tasks[index];
         final assignedName = task.assignedPatientId != null
             ? patientNames[task.assignedPatientId] ?? "Unknown Patient"
             : "Unassigned";
@@ -92,7 +97,6 @@ class TaskListDay extends StatelessWidget {
               subtitle: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  // Wrap prevents overflow on small screens
                   Wrap(
                     crossAxisAlignment: WrapCrossAlignment.center,
                     spacing: 8,
@@ -141,15 +145,14 @@ class TaskListDay extends StatelessWidget {
                         onPressed: () async {
                           final newStatus = !task.isComplete;
                           setState(() => task.isComplete = newStatus);
-
-                          // Optional backend sync
                           try {
                             await updateCompletion(task.id!, newStatus);
                           } catch (e) {
-                            // Roll back the change if API failed
                             setState(() => task.isComplete = !newStatus);
                             ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(content: Text("Failed to update task")),
+                              const SnackBar(
+                                content: Text("Failed to update task"),
+                              ),
                             );
                           }
                         },
@@ -176,7 +179,7 @@ class TaskListDay extends StatelessWidget {
             );
           },
         );
-      }).toList(),
+      },
     );
   }
 }

--- a/careconnect2025/frontend/lib/features/tasks/presentation/widgets/task_list_week.dart
+++ b/careconnect2025/frontend/lib/features/tasks/presentation/widgets/task_list_week.dart
@@ -69,8 +69,13 @@ class TaskListWeek extends StatelessWidget {
         return a.name.compareTo(b.name);
       });
 
-    return Column(
-      children: tasks.map((task) {
+    return ListView.builder(
+      shrinkWrap: true,
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.only(bottom: 16),
+      itemCount: tasks.length,
+      itemBuilder: (context, index) {
+        final task = tasks[index];
         final assignedName = task.assignedPatientId != null
             ? patientNames[task.assignedPatientId] ?? "Unknown Patient"
             : "Unassigned";
@@ -92,7 +97,6 @@ class TaskListWeek extends StatelessWidget {
               subtitle: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  // Use Wrap to avoid overflow on small screens
                   Wrap(
                     crossAxisAlignment: WrapCrossAlignment.center,
                     spacing: 8,
@@ -140,15 +144,14 @@ class TaskListWeek extends StatelessWidget {
                         onPressed: () async {
                           final newStatus = !task.isComplete;
                           setState(() => task.isComplete = newStatus);
-
-                          // Optional backend sync
                           try {
                             await updateCompletion(task.id!, newStatus);
                           } catch (e) {
-                            // Roll back the change if API failed
                             setState(() => task.isComplete = !newStatus);
                             ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(content: Text("Failed to update task")),
+                              const SnackBar(
+                                content: Text("Failed to update task"),
+                              ),
                             );
                           }
                         },
@@ -175,7 +178,7 @@ class TaskListWeek extends StatelessWidget {
             );
           },
         );
-      }).toList(),
+      },
     );
   }
 }

--- a/careconnect2025/frontend/test/calendar_assistant/add_task_button_test.dart
+++ b/careconnect2025/frontend/test/calendar_assistant/add_task_button_test.dart
@@ -1,0 +1,73 @@
+import 'package:care_connect_app/features/tasks/presentation/widgets/add_task_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AddTaskButton Widget', () {
+    testWidgets('renders labeled button on wide screens', (tester) async {
+      bool pressed = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(size: Size(800, 800)), // wide screen
+            child: Scaffold(
+              body: Center(
+                child: SizedBox(
+                  width: 800,
+                  height: 600,
+                  child: AddTaskButton(onPressed: () => pressed = true),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // The button should show label text
+      expect(find.text('Add Task'), findsOneWidget);
+
+      // Tap by text (safe even if Flutter changes internal class)
+      await tester.tap(find.text('Add Task'));
+      await tester.pumpAndSettle();
+
+      expect(pressed, isTrue);
+    });
+
+    testWidgets('renders icon-only button on compact screens', (tester) async {
+      bool pressed = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(size: Size(300, 800)), // narrow screen
+            child: Scaffold(
+              body: Center(
+                child: SizedBox(
+                  width: 300,
+                  height: 600,
+                  child: AddTaskButton(onPressed: () => pressed = true),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Should show only the icon version (no text)
+      expect(find.byType(IconButton), findsOneWidget);
+      expect(find.byIcon(Icons.add), findsOneWidget);
+      expect(find.text('Add Task'), findsNothing);
+
+      // Tap the icon and verify callback fired
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+
+      expect(pressed, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
The branch requesting to be merged fixes the issues found from last demo for the Calendar Assistant, these changes are:

- Adding the ability to change the date in single tasks
- Adding fix for longer task lists to become scrollable and not crush other screen widgets/overflow
- Setting list area to be 20% of the screen to allow for nature size and layout but still allowing for responsiveness
- Update the Import Button to collapse to just icon on thinner screens
- Moved Add Task button to its own widget, this allows for:
 -- Cleaner and more separated code
 -- Add Task Button to respect themes and color schemes set by app
 -- Allows Add Task bar to collapse to just icon when screen is thinner
 -- Adding Unit test file to go with new widget
 - Fixed Monthly header to be abbreviated name then year per professor's request.