### PR TITLE
334-Codyjwhite-EssayAssistantImprovements

### DIFF
--- a/LearningLens2025/frontend/lib/Views/essay_assistant.dart
+++ b/LearningLens2025/frontend/lib/Views/essay_assistant.dart
@@ -36,7 +36,8 @@ import 'package:uuid/uuid.dart';
 import 'package:vsc_quill_delta_to_html/vsc_quill_delta_to_html.dart';
 import 'package:markdown/markdown.dart' as md;
 import 'package:super_clipboard/super_clipboard.dart';
-import 'package:flutter_quill_delta_from_html/flutter_quill_delta_from_html.dart' as qh;
+import 'package:flutter_quill_delta_from_html/flutter_quill_delta_from_html.dart'
+    as qh;
 
 // Api
 import 'package:learninglens_app/Api/database/ai_logging_singleton.dart';
@@ -150,6 +151,7 @@ String removeHtmlTags(String htmlText) {
 bool _hasKeyFor(LlmType llm) {
   return LocalStorageService.userHasLlmKey(llm);
 }
+
 /// Convert markdown text to HTML
 String _markdownToHTML(String markdownText) {
   return md.markdownToHtml(markdownText);
@@ -161,7 +163,8 @@ String _markdownToPlain(String mdText) {
 
   // Replace fenced code blocks
   s = s.replaceAllMapped(RegExp(r'```[\s\S]*?```'), (m) {
-    final inner = m.group(0)!
+    final inner = m
+        .group(0)!
         .replaceFirst(RegExp(r'^```[^\n]*\n'), '')
         .replaceAll('```', '');
     return inner;
@@ -186,12 +189,12 @@ String _markdownToPlain(String mdText) {
   // Collapse triple newlines
   s = s.replaceAll(RegExp(r'\n{3,}'), '\n\n');
 
-  s = s.replaceAll(RegExp(r'\r\n?'), '\n');   // unify line endings
-  s = s.replaceAll(RegExp(r'\n{2,}'), '\n\n'); // one blank line between paragraphs
+  s = s.replaceAll(RegExp(r'\r\n?'), '\n'); // unify line endings
+  s = s.replaceAll(
+      RegExp(r'\n{2,}'), '\n\n'); // one blank line between paragraphs
 
   return s.trim();
 }
-
 
 /// Copy rich markdown as HTML to clipboard
 Future<void> _copyMarkdown(BuildContext context, String mdText) async {
@@ -1394,39 +1397,42 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
                                 padding: const EdgeInsets.symmetric(
                                     vertical: 8.0, horizontal: 12.0),
                                 child: _AssistantMessageCard(
-                                    text: text, // raw markdown that you already computed above
-                                    child: Container(
-                                      width: double.infinity,
-                                      padding: const EdgeInsets.all(12),
-                                      decoration: BoxDecoration(
-                                        color: Theme.of(context).colorScheme.primaryContainer,
-                                        borderRadius: BorderRadius.circular(12),
-                                      ),
-                                  child: MarkdownBody(
-                                    data: text,
-                                    selectable:
-                                        true, // lets users highlight/copy text
-                                    styleSheet: MarkdownStyleSheet.fromTheme(
-                                            Theme.of(context))
-                                        .copyWith(
-                                      p: const TextStyle(
-                                          fontSize: 16,
-                                          color: Colors.black87,
-                                          height: 1.46),
-                                      strong: const TextStyle(
-                                          fontWeight: FontWeight.bold),
-                                      em: const TextStyle(
-                                          fontStyle: FontStyle.italic),
-                                      a: const TextStyle(
-                                        color: Colors.blueAccent,
-                                        decoration: TextDecoration.underline,
-                                      ) 
+                                  text:
+                                      text, // raw markdown that you already computed above
+                                  child: Container(
+                                    width: double.infinity,
+                                    padding: const EdgeInsets.all(12),
+                                    decoration: BoxDecoration(
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .primaryContainer,
+                                      borderRadius: BorderRadius.circular(12),
+                                    ),
+                                    child: MarkdownBody(
+                                      data: text,
+                                      selectable:
+                                          true, // lets users highlight/copy text
+                                      styleSheet: MarkdownStyleSheet.fromTheme(
+                                              Theme.of(context))
+                                          .copyWith(
+                                              p: const TextStyle(
+                                                  fontSize: 16,
+                                                  color: Colors.black87,
+                                                  height: 1.46),
+                                              strong: const TextStyle(
+                                                  fontWeight: FontWeight.bold),
+                                              em: const TextStyle(
+                                                  fontStyle: FontStyle.italic),
+                                              a: const TextStyle(
+                                                color: Colors.blueAccent,
+                                                decoration:
+                                                    TextDecoration.underline,
+                                              )),
                                     ),
                                   ),
                                 ),
-                              ),
-                            );
-                          }
+                              );
+                            }
 
                             // (2) User messages (right-aligned bubble)
                             if (m is types.TextMessage &&
@@ -2066,63 +2072,71 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
     }
   }
 
-  Future<void> _richPaste(BuildContext editorCtx, quill.QuillController controller) async {
-  final sys = SystemClipboard.instance;
-  if (sys == null) {
-    // super_clipboard not available → let default paste run
-    Actions.invoke(editorCtx, const PasteTextIntent(SelectionChangedCause.keyboard));
-    return;
-  }
-
-  final reader = await sys.read();
-
-  String normalizeLineBreaks(String rawHtml) {
-    var h = rawHtml;
-    final startIdx = h.indexOf('<!--StartFragment-->');
-    final endIdx = h.indexOf('<!--EndFragment-->');
-    if (startIdx != -1 && endIdx != -1 && endIdx > startIdx) {
-      h = h.substring(startIdx + '<!--StartFragment-->'.length, endIdx);
-    }
-    h = h.replaceAll(RegExp(r'<br\s*/?>', caseSensitive: false), '\n');
-    h = h.replaceAll(RegExp(r'\n{2,}'), '</p><p>');
-    if (!RegExp(r'</?(p|div|ul|ol|h[1-6])\b', caseSensitive: false).hasMatch(h)) {
-      h = '<p>$h</p>';
-    }
-    h = h.replaceAll('\n', '<br/>');
-    return h;
-  }
-
-  if (reader.canProvide(Formats.htmlText)) {
-    var html = await reader.readValue(Formats.htmlText);
-    if (html != null && html.trim().isNotEmpty) {
-      html = normalizeLineBreaks(html);
-      final delta = qh.HtmlToDelta().convert(html);
-
-      final sel = controller.selection;
-      final base = sel.baseOffset;
-      final extent = sel.extentOffset;
-      final deleteLen = (extent - base).abs();
-
-      controller.replaceText(
-        base, deleteLen, '', TextSelection.collapsed(offset: base),
-      );
-      controller.compose(delta, controller.selection, quill.ChangeSource.local);
-      controller.updateSelection(
-        TextSelection.collapsed(offset: base + delta.length),
-        quill.ChangeSource.local,
-      );
+  Future<void> _richPaste(
+      BuildContext editorCtx, quill.QuillController controller) async {
+    final sys = SystemClipboard.instance;
+    if (sys == null) {
+      // super_clipboard not available → let default paste run
+      Actions.invoke(
+          editorCtx, const PasteTextIntent(SelectionChangedCause.keyboard));
       return;
     }
-  }
 
-  // fallback to normal paste (plain text)
-  Actions.invoke(editorCtx, const PasteTextIntent(SelectionChangedCause.keyboard));
-}
+    final reader = await sys.read();
+
+    String normalizeLineBreaks(String rawHtml) {
+      var h = rawHtml;
+      final startIdx = h.indexOf('<!--StartFragment-->');
+      final endIdx = h.indexOf('<!--EndFragment-->');
+      if (startIdx != -1 && endIdx != -1 && endIdx > startIdx) {
+        h = h.substring(startIdx + '<!--StartFragment-->'.length, endIdx);
+      }
+      h = h.replaceAll(RegExp(r'<br\s*/?>', caseSensitive: false), '\n');
+      h = h.replaceAll(RegExp(r'\n{2,}'), '</p><p>');
+      if (!RegExp(r'</?(p|div|ul|ol|h[1-6])\b', caseSensitive: false)
+          .hasMatch(h)) {
+        h = '<p>$h</p>';
+      }
+      h = h.replaceAll('\n', '<br/>');
+      return h;
+    }
+
+    if (reader.canProvide(Formats.htmlText)) {
+      var html = await reader.readValue(Formats.htmlText);
+      if (html != null && html.trim().isNotEmpty) {
+        html = normalizeLineBreaks(html);
+        final delta = qh.HtmlToDelta().convert(html);
+
+        final sel = controller.selection;
+        final base = sel.baseOffset;
+        final extent = sel.extentOffset;
+        final deleteLen = (extent - base).abs();
+
+        controller.replaceText(
+          base,
+          deleteLen,
+          '',
+          TextSelection.collapsed(offset: base),
+        );
+        controller.compose(
+            delta, controller.selection, quill.ChangeSource.local);
+        controller.updateSelection(
+          TextSelection.collapsed(offset: base + delta.length),
+          quill.ChangeSource.local,
+        );
+        return;
+      }
+    }
+
+    // fallback to normal paste (plain text)
+    Actions.invoke(
+        editorCtx, const PasteTextIntent(SelectionChangedCause.keyboard));
+  }
 
   Widget _richPasteWrapper({
     required quill.QuillController controller,
     required Widget child,
-    void Function(BuildContext ctx)? onInnerContext, 
+    void Function(BuildContext ctx)? onInnerContext,
   }) {
     late BuildContext editorCtx;
 
@@ -2142,7 +2156,7 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
         child: Builder(
           builder: (inner) {
             editorCtx = inner;
-            onInnerContext?.call(editorCtx); 
+            onInnerContext?.call(editorCtx);
             return child;
           },
         ),
@@ -2150,47 +2164,45 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
     );
   }
 
-
   /// Open the Quill editor dialog for a given essay (or "general draft" if null).
   /// Saves the draft (Quill delta JSON) locally in `_drafts` and via stubbed backend.
   void _openQuillEditorDialogFor(Assignment? essay) async {
     if (!_sessionActive) return;
 
-    BuildContext? _draftEditorCtx;
+    BuildContext? draftEditorCtx;
 
-        Widget _editorWithContextMenuForDraft() {
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
-      onSecondaryTapDown: (details) async {
-        // Show a desktop-style context menu with Paste (rich)
-        final selected = await showMenu<String>(
-          context: context,
-          position: RelativeRect.fromLTRB(
-            details.globalPosition.dx,
-            details.globalPosition.dy,
-            details.globalPosition.dx,
-            details.globalPosition.dy,
+    Widget editorWithContextMenuForDraft() {
+      return GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onSecondaryTapDown: (details) async {
+          // Show a desktop-style context menu with Paste (rich)
+          final selected = await showMenu<String>(
+            context: context,
+            position: RelativeRect.fromLTRB(
+              details.globalPosition.dx,
+              details.globalPosition.dy,
+              details.globalPosition.dx,
+              details.globalPosition.dy,
+            ),
+            items: const [
+              PopupMenuItem(value: 'paste_rich', child: Text('Paste (rich)')),
+            ],
+          );
+          if (selected == 'paste_rich' && draftEditorCtx != null) {
+            _richPaste(draftEditorCtx!, _quillDraftController);
+          }
+        },
+        child: quill.QuillEditor(
+          focusNode: _draftFocus,
+          scrollController: _quillDraftScrollController,
+          controller: _quillDraftController,
+          config: const quill.QuillEditorConfig(
+            padding: EdgeInsets.fromLTRB(24, 20, 24, 28),
+            placeholder: 'Write your essay here…',
           ),
-          items: const [
-            PopupMenuItem(value: 'paste_rich', child: Text('Paste (rich)')),
-          ],
-        );
-        if (selected == 'paste_rich' && _draftEditorCtx != null) {
-          _richPaste(_draftEditorCtx!, _quillDraftController);
-        }
-      },
-      child: quill.QuillEditor(
-        focusNode: _draftFocus,
-        scrollController: _quillDraftScrollController,
-        controller: _quillDraftController,
-        config: const quill.QuillEditorConfig(
-          padding: EdgeInsets.fromLTRB(24, 20, 24, 28),
-          placeholder: 'Write your essay here…',
         ),
-      ),
-    );
-  }
-    
+      );
+    }
 
     // Load current session draft
     if (_currentSession!.draftDeltaOps != null) {
@@ -2247,33 +2259,33 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
                     const Divider(height: 1),
 
                     // ----- Toolbar (simple) -----
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 8),
-                    child: Row(
-                      children: [
-                        IconButton(
-                          tooltip: 'Paste (rich)',
-                          icon: const Icon(Icons.content_paste),
-                          onPressed: () {
-                            final ctx = _draftEditorCtx ?? context;
-                            _richPaste(ctx, _quillDraftController);
-                          },
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: quill.QuillSimpleToolbar(
-                            controller: _quillDraftController,
-                            config: const quill.QuillSimpleToolbarConfig(
-                              multiRowsDisplay: true,
-                              showDividers: true,
-                              showClipboardPaste: false,
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: Row(
+                        children: [
+                          IconButton(
+                            tooltip: 'Paste (rich)',
+                            icon: const Icon(Icons.content_paste),
+                            onPressed: () {
+                              final ctx = draftEditorCtx ?? context;
+                              _richPaste(ctx, _quillDraftController);
+                            },
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: quill.QuillSimpleToolbar(
+                              controller: _quillDraftController,
+                              config: const quill.QuillSimpleToolbarConfig(
+                                multiRowsDisplay: true,
+                                showDividers: true,
+                                showClipboardPaste: false,
+                              ),
                             ),
                           ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
-                  ),
-                  const Divider(height: 1),
+                    const Divider(height: 1),
 
                     // ----- Editor area -----
                     Expanded(
@@ -2293,10 +2305,10 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
                           ),
                           child: _richPasteWrapper(
                             controller: _quillDraftController,
-                            onInnerContext: (ctx) => _draftEditorCtx = ctx, 
-                            child: _editorWithContextMenuForDraft(),     
+                            onInnerContext: (ctx) => draftEditorCtx = ctx,
+                            child: editorWithContextMenuForDraft(),
                           ),
-                                                  ),
+                        ),
                       ),
                     ),
                     // ----- Footer (Save / Cancel) -----
@@ -2402,11 +2414,10 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
   /// Open the Quill notes editor dialog for a given essay (or "general notes" if null).
   void _openNotesEditorDialogFor(Assignment? essay) async {
     if (!_sessionActive) return;
-    
-    BuildContext? _notesEditorCtx;
 
-    
-    Widget _editorWithContextMenuForNotes() {
+    BuildContext? notesEditorCtx;
+
+    Widget editorWithContextMenuForNotes() {
       return GestureDetector(
         behavior: HitTestBehavior.translucent,
         onSecondaryTapDown: (details) async {
@@ -2424,8 +2435,8 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
             ],
           );
           // ignore: unnecessary_null_comparison
-          if (selected == 'paste_rich' && _notesEditorCtx != null) {
-            _richPaste(_notesEditorCtx!, _quillNotesController);
+          if (selected == 'paste_rich' && notesEditorCtx != null) {
+            _richPaste(notesEditorCtx!, _quillNotesController);
           }
         },
         child: quill.QuillEditor(
@@ -2485,32 +2496,32 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
                 const Divider(height: 1),
 
                 // Toolbar
-                                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 8),
-                    child: Row(
-                      children: [
-                        IconButton(
-                          tooltip: 'Paste (rich)',
-                          icon: const Icon(Icons.content_paste),
-                          onPressed: () {
-                            final ctx = _notesEditorCtx ?? context;
-                            _richPaste(ctx, _quillNotesController);
-                          },
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: quill.QuillSimpleToolbar(
-                            controller: _quillNotesController,
-                            config: const quill.QuillSimpleToolbarConfig(
-                              multiRowsDisplay: true,
-                              showDividers: true,
-                              showClipboardPaste: false,
-                            ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Row(
+                    children: [
+                      IconButton(
+                        tooltip: 'Paste (rich)',
+                        icon: const Icon(Icons.content_paste),
+                        onPressed: () {
+                          final ctx = notesEditorCtx ?? context;
+                          _richPaste(ctx, _quillNotesController);
+                        },
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: quill.QuillSimpleToolbar(
+                          controller: _quillNotesController,
+                          config: const quill.QuillSimpleToolbarConfig(
+                            multiRowsDisplay: true,
+                            showDividers: true,
+                            showClipboardPaste: false,
                           ),
                         ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
+                ),
                 const Divider(height: 1),
 
                 // Editor
@@ -2518,25 +2529,24 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
                   child: Padding(
                     padding: const EdgeInsets.all(8),
                     child: DecoratedBox(
-                      decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.surface,
-                        borderRadius: BorderRadius.circular(12),
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black.withOpacity(0.05),
-                            blurRadius: 6,
-                            offset: const Offset(0, 2),
-                          ),
-                        ],
-                      ),
-                  child: _richPasteWrapper(
-                    controller: _quillNotesController,
-                    onInnerContext: (ctx) => _notesEditorCtx = ctx, 
-                    child: _editorWithContextMenuForNotes(), 
-                  )
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.surface,
+                          borderRadius: BorderRadius.circular(12),
+                          boxShadow: [
+                            BoxShadow(
+                              color: Colors.black.withOpacity(0.05),
+                              blurRadius: 6,
+                              offset: const Offset(0, 2),
+                            ),
+                          ],
+                        ),
+                        child: _richPasteWrapper(
+                          controller: _quillNotesController,
+                          onInnerContext: (ctx) => notesEditorCtx = ctx,
+                          child: editorWithContextMenuForNotes(),
+                        )),
+                  ),
                 ),
-              ),
-            ),
                 // Footer
                 Padding(
                   padding: const EdgeInsets.fromLTRB(16, 10, 16, 16),
@@ -2596,26 +2606,22 @@ class _AssistantMessageCard extends StatelessWidget {
   const _AssistantMessageCard({
     required this.text,
     required this.child,
-    super.key,
   });
   final String text;
   final Widget child;
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        child,
-        Positioned(
+    return Stack(children: [
+      child,
+      Positioned(
           right: 8,
           top: 8,
           child: IconButton(
             tooltip: 'Copy to clipboard',
             icon: const Icon(Icons.copy, size: 18),
             onPressed: () => _copyMarkdown(context, text),
-          )
-        )
-      ]
-    ); 
+          ))
+    ]);
   }
 }
 

--- a/LearningLens2025/frontend/lib/Views/essay_assistant.dart
+++ b/LearningLens2025/frontend/lib/Views/essay_assistant.dart
@@ -34,6 +34,9 @@ import 'package:flutter_quill/flutter_quill.dart' as quill;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 import 'package:vsc_quill_delta_to_html/vsc_quill_delta_to_html.dart';
+import 'package:markdown/markdown.dart' as md;
+import 'package:super_clipboard/super_clipboard.dart';
+import 'package:flutter_quill_delta_from_html/flutter_quill_delta_from_html.dart' as qh;
 
 // Api
 import 'package:learninglens_app/Api/database/ai_logging_singleton.dart';
@@ -47,7 +50,6 @@ import 'package:learninglens_app/Api/lms/factory/lms_factory.dart';
 import 'package:learninglens_app/Api/lms/moodle/moodle_lms_service.dart';
 // Controller
 import 'package:learninglens_app/Controller/custom_appbar.dart';
-// Views
 // beans
 import 'package:learninglens_app/beans/ai_log.dart';
 import 'package:learninglens_app/beans/assignment.dart';
@@ -147,6 +149,65 @@ String removeHtmlTags(String htmlText) {
 // Check if user has API key for selected LLM
 bool _hasKeyFor(LlmType llm) {
   return LocalStorageService.userHasLlmKey(llm);
+}
+/// Convert markdown text to HTML
+String _markdownToHTML(String markdownText) {
+  return md.markdownToHtml(markdownText);
+}
+
+String _markdownToPlain(String mdText) {
+  // lightweight, good enough for fallback
+  var s = mdText;
+
+  // Replace fenced code blocks
+  s = s.replaceAllMapped(RegExp(r'```[\s\S]*?```'), (m) {
+    final inner = m.group(0)!
+        .replaceFirst(RegExp(r'^```[^\n]*\n'), '')
+        .replaceAll('```', '');
+    return inner;
+  });
+
+  // Inline code
+  s = s.replaceAll(RegExp(r'`([^`]*)`'), r'\1');
+
+  // Images
+  s = s.replaceAll(RegExp(r'!\[.*?\]\(.*?\)'), '');
+
+  // Links → "text (url)"
+  s = s.replaceAllMapped(
+      RegExp(r'\[([^\]]+)\]\(([^)]+)\)'), (m) => '${m[1]} (${m[2]})');
+
+  // Remove emphasis, quotes, tildes
+  s = s.replaceAll(RegExp(r'(^|\s)[*_]{1,3}|\~\~|^>+\s*', multiLine: true), '');
+
+  // Bullet points
+  s = s.replaceAll(RegExp(r'^\s*[-*]\s+', multiLine: true), '• ');
+
+  // Collapse triple newlines
+  s = s.replaceAll(RegExp(r'\n{3,}'), '\n\n');
+
+  s = s.replaceAll(RegExp(r'\r\n?'), '\n');   // unify line endings
+  s = s.replaceAll(RegExp(r'\n{2,}'), '\n\n'); // one blank line between paragraphs
+
+  return s.trim();
+}
+
+
+/// Copy rich markdown as HTML to clipboard
+Future<void> _copyMarkdown(BuildContext context, String mdText) async {
+  final htmlText = _markdownToHTML(mdText);
+  final plain = _markdownToPlain(mdText);
+
+  final item = DataWriterItem();
+  item.add(Formats.htmlText(htmlText));
+  item.add(Formats.plainText(plain));
+  await SystemClipboard.instance?.write([item]);
+
+  if (context.mounted) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Copied rich text to clipboard.')),
+    );
+  }
 }
 
 /* ────────────────────────────────────────────────────────────────────────────
@@ -378,21 +439,9 @@ class _EssayAssistantState extends State<EssayAssistant> {
     _postIntroMsg();
 
     // Quill controller with basic config (external rich paste enabled)
-    _quillDraftController = quill.QuillController.basic(
-      config: const quill.QuillControllerConfig(
-        clipboardConfig: quill.QuillClipboardConfig(
-          enableExternalRichPaste: true,
-        ),
-      ),
-    );
+    _quillDraftController = quill.QuillController.basic();
     // Notes editor
-    _quillNotesController = quill.QuillController.basic(
-      config: const quill.QuillControllerConfig(
-        clipboardConfig: quill.QuillClipboardConfig(
-          enableExternalRichPaste: true,
-        ),
-      ),
-    );
+    _quillNotesController = quill.QuillController.basic();
 
     // Load essays from LMS into left sidebar
     _loadEssays();
@@ -444,13 +493,13 @@ These are pre-built tools that perform focused tasks — such as checking gramma
 Use this to capture quick ideas, reminders, or references as you work. Notes stay linked to your essay session so you won’t lose your thoughts between sessions.
 
 **Draft Editor:**\n
-This is your main writing space. You can write freely, review feedback from the assistant, and make revisions directly here. When you’re ready, you can export or submit your final essay.
+This is your main writing space. You can write freely, review feedback from the assistant, and make revisions directly here. When you’re ready, you can export or submit your final essay.\n
 
-**Select an essay from the left sidebar to get started!**
+**Select an essay from the left sidebar to get started!**\n
 
-Tip: The assistant adapts to your mode and notes, so the more context you provide, the better it can help.
+Tip: The assistant adapts to your mode and notes, so the more context you provide, the better it can help.\n
 
-⚠️ **Important Notice** ⚠️
+⚠️ **Important Notice** ⚠️\n
 
 **The Essay Assistant provides AI-generated feedback and content suggestions. While it strives for accuracy and quality, it is your responsibility to verify all information, citations, and factual claims before submission. Always review and edit the final essay to ensure it meets your academic standards and requirements.**
       ''');
@@ -1344,15 +1393,15 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
                               return Padding(
                                 padding: const EdgeInsets.symmetric(
                                     vertical: 8.0, horizontal: 12.0),
-                                child: Container(
-                                  width: double.infinity,
-                                  padding: const EdgeInsets.all(12),
-                                  decoration: BoxDecoration(
-                                    color: Theme.of(context)
-                                        .colorScheme
-                                        .primaryContainer,
-                                    borderRadius: BorderRadius.circular(12),
-                                  ),
+                                child: _AssistantMessageCard(
+                                    text: text, // raw markdown that you already computed above
+                                    child: Container(
+                                      width: double.infinity,
+                                      padding: const EdgeInsets.all(12),
+                                      decoration: BoxDecoration(
+                                        color: Theme.of(context).colorScheme.primaryContainer,
+                                        borderRadius: BorderRadius.circular(12),
+                                      ),
                                   child: MarkdownBody(
                                     data: text,
                                     selectable:
@@ -1371,12 +1420,13 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
                                       a: const TextStyle(
                                         color: Colors.blueAccent,
                                         decoration: TextDecoration.underline,
-                                      ),
+                                      ) 
                                     ),
                                   ),
                                 ),
-                              );
-                            }
+                              ),
+                            );
+                          }
 
                             // (2) User messages (right-aligned bubble)
                             if (m is types.TextMessage &&
@@ -2016,10 +2066,131 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
     }
   }
 
+  Future<void> _richPaste(BuildContext editorCtx, quill.QuillController controller) async {
+  final sys = SystemClipboard.instance;
+  if (sys == null) {
+    // super_clipboard not available → let default paste run
+    Actions.invoke(editorCtx, const PasteTextIntent(SelectionChangedCause.keyboard));
+    return;
+  }
+
+  final reader = await sys.read();
+
+  String normalizeLineBreaks(String rawHtml) {
+    var h = rawHtml;
+    final startIdx = h.indexOf('<!--StartFragment-->');
+    final endIdx = h.indexOf('<!--EndFragment-->');
+    if (startIdx != -1 && endIdx != -1 && endIdx > startIdx) {
+      h = h.substring(startIdx + '<!--StartFragment-->'.length, endIdx);
+    }
+    h = h.replaceAll(RegExp(r'<br\s*/?>', caseSensitive: false), '\n');
+    h = h.replaceAll(RegExp(r'\n{2,}'), '</p><p>');
+    if (!RegExp(r'</?(p|div|ul|ol|h[1-6])\b', caseSensitive: false).hasMatch(h)) {
+      h = '<p>$h</p>';
+    }
+    h = h.replaceAll('\n', '<br/>');
+    return h;
+  }
+
+  if (reader.canProvide(Formats.htmlText)) {
+    var html = await reader.readValue(Formats.htmlText);
+    if (html != null && html.trim().isNotEmpty) {
+      html = normalizeLineBreaks(html);
+      final delta = qh.HtmlToDelta().convert(html);
+
+      final sel = controller.selection;
+      final base = sel.baseOffset;
+      final extent = sel.extentOffset;
+      final deleteLen = (extent - base).abs();
+
+      controller.replaceText(
+        base, deleteLen, '', TextSelection.collapsed(offset: base),
+      );
+      controller.compose(delta, controller.selection, quill.ChangeSource.local);
+      controller.updateSelection(
+        TextSelection.collapsed(offset: base + delta.length),
+        quill.ChangeSource.local,
+      );
+      return;
+    }
+  }
+
+  // fallback to normal paste (plain text)
+  Actions.invoke(editorCtx, const PasteTextIntent(SelectionChangedCause.keyboard));
+}
+
+  Widget _richPasteWrapper({
+    required quill.QuillController controller,
+    required Widget child,
+    void Function(BuildContext ctx)? onInnerContext, 
+  }) {
+    late BuildContext editorCtx;
+
+    return Shortcuts(
+      shortcuts: {
+        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyV):
+            const PasteTextIntent(SelectionChangedCause.keyboard),
+        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyV):
+            const PasteTextIntent(SelectionChangedCause.keyboard),
+      },
+      child: Actions(
+        actions: {
+          PasteTextIntent: CallbackAction<PasteTextIntent>(
+            onInvoke: (_) => _richPaste(editorCtx, controller),
+          ),
+        },
+        child: Builder(
+          builder: (inner) {
+            editorCtx = inner;
+            onInnerContext?.call(editorCtx); 
+            return child;
+          },
+        ),
+      ),
+    );
+  }
+
+
   /// Open the Quill editor dialog for a given essay (or "general draft" if null).
   /// Saves the draft (Quill delta JSON) locally in `_drafts` and via stubbed backend.
   void _openQuillEditorDialogFor(Assignment? essay) async {
     if (!_sessionActive) return;
+
+    BuildContext? _draftEditorCtx;
+
+        Widget _editorWithContextMenuForDraft() {
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onSecondaryTapDown: (details) async {
+        // Show a desktop-style context menu with Paste (rich)
+        final selected = await showMenu<String>(
+          context: context,
+          position: RelativeRect.fromLTRB(
+            details.globalPosition.dx,
+            details.globalPosition.dy,
+            details.globalPosition.dx,
+            details.globalPosition.dy,
+          ),
+          items: const [
+            PopupMenuItem(value: 'paste_rich', child: Text('Paste (rich)')),
+          ],
+        );
+        if (selected == 'paste_rich' && _draftEditorCtx != null) {
+          _richPaste(_draftEditorCtx!, _quillDraftController);
+        }
+      },
+      child: quill.QuillEditor(
+        focusNode: _draftFocus,
+        scrollController: _quillDraftScrollController,
+        controller: _quillDraftController,
+        config: const quill.QuillEditorConfig(
+          padding: EdgeInsets.fromLTRB(24, 20, 24, 28),
+          placeholder: 'Write your essay here…',
+        ),
+      ),
+    );
+  }
+    
 
     // Load current session draft
     if (_currentSession!.draftDeltaOps != null) {
@@ -2076,18 +2247,33 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
                     const Divider(height: 1),
 
                     // ----- Toolbar (simple) -----
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 8),
-                      child: quill.QuillSimpleToolbar(
-                        controller: _quillDraftController,
-                        config: const quill.QuillSimpleToolbarConfig(
-                          multiRowsDisplay: true,
-                          showDividers: true,
-                          showClipboardPaste: true,
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    child: Row(
+                      children: [
+                        IconButton(
+                          tooltip: 'Paste (rich)',
+                          icon: const Icon(Icons.content_paste),
+                          onPressed: () {
+                            final ctx = _draftEditorCtx ?? context;
+                            _richPaste(ctx, _quillDraftController);
+                          },
                         ),
-                      ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: quill.QuillSimpleToolbar(
+                            controller: _quillDraftController,
+                            config: const quill.QuillSimpleToolbarConfig(
+                              multiRowsDisplay: true,
+                              showDividers: true,
+                              showClipboardPaste: false,
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
-                    const Divider(height: 1),
+                  ),
+                  const Divider(height: 1),
 
                     // ----- Editor area -----
                     Expanded(
@@ -2105,17 +2291,12 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
                               ),
                             ],
                           ),
-                          child: quill.QuillEditor(
-                            focusNode: _draftFocus,
-                            scrollController: _quillDraftScrollController,
+                          child: _richPasteWrapper(
                             controller: _quillDraftController,
-                            config: const quill.QuillEditorConfig(
-                              // feels like page margins
-                              padding: EdgeInsets.fromLTRB(24, 20, 24, 28),
-                              placeholder: 'Write your essay here…',
-                            ),
+                            onInnerContext: (ctx) => _draftEditorCtx = ctx, 
+                            child: _editorWithContextMenuForDraft(),     
                           ),
-                        ),
+                                                  ),
                       ),
                     ),
                     // ----- Footer (Save / Cancel) -----
@@ -2221,6 +2402,43 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
   /// Open the Quill notes editor dialog for a given essay (or "general notes" if null).
   void _openNotesEditorDialogFor(Assignment? essay) async {
     if (!_sessionActive) return;
+    
+    BuildContext? _notesEditorCtx;
+
+    
+    Widget _editorWithContextMenuForNotes() {
+      return GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onSecondaryTapDown: (details) async {
+          // Show a desktop-style context menu with Paste (rich)
+          final selected = await showMenu<String>(
+            context: context,
+            position: RelativeRect.fromLTRB(
+              details.globalPosition.dx,
+              details.globalPosition.dy,
+              details.globalPosition.dx,
+              details.globalPosition.dy,
+            ),
+            items: const [
+              PopupMenuItem(value: 'paste_rich', child: Text('Paste (rich)')),
+            ],
+          );
+          // ignore: unnecessary_null_comparison
+          if (selected == 'paste_rich' && _notesEditorCtx != null) {
+            _richPaste(_notesEditorCtx!, _quillNotesController);
+          }
+        },
+        child: quill.QuillEditor(
+          focusNode: _notesFocus,
+          scrollController: _quillNotesScrollController,
+          controller: _quillNotesController,
+          config: const quill.QuillEditorConfig(
+            padding: EdgeInsets.fromLTRB(24, 20, 24, 28),
+            placeholder: 'Take your notes here…',
+          ),
+        ),
+      );
+    }
 
     if (_currentSession!.notesDeltaOps != null) {
       _quillNotesController.document =
@@ -2267,17 +2485,32 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
                 const Divider(height: 1),
 
                 // Toolbar
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 8),
-                  child: quill.QuillSimpleToolbar(
-                    controller: _quillNotesController,
-                    config: const quill.QuillSimpleToolbarConfig(
-                      multiRowsDisplay: true,
-                      showDividers: true,
-                      showClipboardPaste: true,
+                                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    child: Row(
+                      children: [
+                        IconButton(
+                          tooltip: 'Paste (rich)',
+                          icon: const Icon(Icons.content_paste),
+                          onPressed: () {
+                            final ctx = _notesEditorCtx ?? context;
+                            _richPaste(ctx, _quillNotesController);
+                          },
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: quill.QuillSimpleToolbar(
+                            controller: _quillNotesController,
+                            config: const quill.QuillSimpleToolbarConfig(
+                              multiRowsDisplay: true,
+                              showDividers: true,
+                              showClipboardPaste: false,
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
                   ),
-                ),
                 const Divider(height: 1),
 
                 // Editor
@@ -2296,20 +2529,14 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
                           ),
                         ],
                       ),
-                      child: quill.QuillEditor(
-                        focusNode: _notesFocus,
-                        scrollController: _quillNotesScrollController,
-                        controller: _quillNotesController,
-                        config: const quill.QuillEditorConfig(
-                          // feels like page margins
-                          padding: EdgeInsets.fromLTRB(24, 20, 24, 28),
-                          placeholder: 'Write your notes here…',
-                        ),
-                      ),
-                    ),
-                  ),
+                  child: _richPasteWrapper(
+                    controller: _quillNotesController,
+                    onInnerContext: (ctx) => _notesEditorCtx = ctx, 
+                    child: _editorWithContextMenuForNotes(), 
+                  )
                 ),
-
+              ),
+            ),
                 // Footer
                 Padding(
                   padding: const EdgeInsets.fromLTRB(16, 10, 16, 16),
@@ -2364,6 +2591,33 @@ Tip: The assistant adapts to your mode and notes, so the more context you provid
  *  - _EssayModalContent: the centered dialog content for an assignment
  *  - _LabeledRow: neat label/value row used in the dialog body
  * ──────────────────────────────────────────────────────────────────────────── */
+
+class _AssistantMessageCard extends StatelessWidget {
+  const _AssistantMessageCard({
+    required this.text,
+    required this.child,
+    super.key,
+  });
+  final String text;
+  final Widget child;
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        child,
+        Positioned(
+          right: 8,
+          top: 8,
+          child: IconButton(
+            tooltip: 'Copy to clipboard',
+            icon: const Icon(Icons.copy, size: 18),
+            onPressed: () => _copyMarkdown(context, text),
+          )
+        )
+      ]
+    ); 
+  }
+}
 
 /// Essay details modal content (title, due, description, actions).
 class _EssayModalContent extends StatelessWidget {

--- a/LearningLens2025/frontend/lib/Views/view_reflection_page.dart
+++ b/LearningLens2025/frontend/lib/Views/view_reflection_page.dart
@@ -7,10 +7,10 @@ class ViewReflectionPage extends StatelessWidget {
   final Submission submission;
 
   const ViewReflectionPage({
-    Key? key,
+    super.key,
     required this.participant,
     required this.submission,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/LearningLens2025/frontend/lib/services/prompt_builder_service.dart
+++ b/LearningLens2025/frontend/lib/services/prompt_builder_service.dart
@@ -116,35 +116,45 @@ PermTokens essayAssistPromptBuilder(AiMode mode, String? submissionText,
 
   // Base core instructions
   core += '''
-      You are an AI assistant designed to help students write and improve essays. Provide clear, concise, and accurate information in a friendly and approachable manner. Always aim to enhance the user's learning experience.
-      Look in the description of the essay assignment for an age or grade level indication and adjust your language and suggestions accordingly. If no indication is found, assume the user is an older student (high school or college level).
-      You have three main modes: Brainstorm, Outline, and Revise. As well as several helper functions.
-      In Brainstorm mode, your main focus is to answer questions and provide suggestions for topics and ideas as well as to help clear up any confusion.
-      In Outline mode, your main focus is to help the user create a structured outline for their essay, including main points and supporting details.
-      In Revise mode, your main focus is to help the user improve their essay by providing feedback on structure, clarity, grammar, and style.
-      If the user submits a prompt that could benefit from a different mode, gently suggest switching modes to better assist them.
-      If the user attempts to ask for examples or for help outside of your instructions, gently remind them of your purpose and that these messages are being logged for review by their teacher.
-      At the end of each response, add a 'Micro-reflection' where you ask the user to reflect on the information provided and how it can help them improve their essay. Focus on reflecting on their use of AI assistance, critical thinking, and research skills.
-      When creating micro-reflection questions, consider the following guidelines:
-      -If suggestions are provided, ask the user how they plan to implement them in their essay
-      -If factual information is provided, ask them to verify it with credible sources.
-      -If sources are provided, ask them to evaluate the credibility and relevance of those sources.
-      -Ask the user to consider how they can apply what they've learned from this interaction to their future writing tasks.
-      -Making challenging questions that promote deeper thinking on the topic is encouraged.
+  You are an AI assistant designed to help students plan, write, and refine their essays. Provide clear, concise, and accurate information in a friendly, approachable tone. Your goal is to enhance the user's learning experience and strengthen their writing skills.
 
-      Your response must follow this exact structure and include all dividers as written.
-      **Mode:** [Current Mode]  
-      ________________________________________________  
-      [Main response content goes here.]  
-      ________________________________________________  
-      **[Reflection greeting]**: [Your micro-reflection question goes here.]  
+  Refer to the essay assignment description for any mention of the student’s age or grade level, and tailor your language and suggestions accordingly. If no such indication is found, assume the user is an older student (high school or college level).
 
-      Do not omit or change the dividers. They must appear exactly as shown (each line should contain 54 underscores)
-      In place of [Reflection greeting], use one of the following:
-      - “Stop and think…”
-      - “Ask yourself…”
-      - “Take a moment to reflect…”
-      ''';
+  You operate in three primary modes—**Brainstorm**, **Outline**, and **Revise**—along with several helper functions:
+  - **Brainstorm mode**: Focus on answering questions, generating ideas, and clarifying topics or points of confusion.
+  - **Outline mode**: Help the user organize their ideas into a structured outline with main points and supporting details.
+  - **Revise mode**: Provide feedback to improve structure, clarity, grammar, and overall writing quality.
+
+  If a user prompt would be better handled in a different mode, gently suggest switching modes to provide more effective assistance.
+
+  If the user requests examples or help outside your defined purpose, politely remind them of your role and that all messages are logged for review by their teacher.
+
+  At the end of every response, include a **Micro-reflection** section to encourage the user to think critically about how the interaction supports their learning and essay development. Micro-reflections should promote thoughtful use of AI, self-evaluation, and research skills.
+
+  When creating micro-reflection questions, follow these guidelines:
+  - If you offered writing suggestions, ask how the user plans to implement them in their essay.  
+  - If you provided factual information, prompt the user to verify it using credible sources.  
+  - If you suggested sources, encourage them to evaluate those sources for credibility and relevance.  
+  - Ask the user how they can apply what they learned from this exchange to future writing tasks.  
+  - Whenever possible, pose thought-provoking questions that promote deeper reflection on the topic.  
+
+  Your response **must** follow this exact structure and include all dividers as shown:
+
+  **Mode:** [Current Mode]  
+  ______________________________________________________  
+  [Main response content goes here.]  
+  ______________________________________________________  
+  **[Reflection greeting]:** [Your micro-reflection question goes here.]  
+
+  Do not change or omit the dividers — each line must contain exactly **54 underscores**. 
+  Always use bullet points over numbered lists unless specifically instructed otherwise by the user. 
+
+  For **[Reflection greeting]**, choose one of the following:
+  - “Stop and think…”  
+  - “Ask yourself…”  
+  - “Take a moment to reflect…”  
+  ''';
+
 
   // Mode-specific instructions
   switch (mode) {

--- a/LearningLens2025/frontend/lib/services/prompt_builder_service.dart
+++ b/LearningLens2025/frontend/lib/services/prompt_builder_service.dart
@@ -155,7 +155,6 @@ PermTokens essayAssistPromptBuilder(AiMode mode, String? submissionText,
   - “Take a moment to reflect…”  
   ''';
 
-
   // Mode-specific instructions
   switch (mode) {
     case AiMode.brainstorm:

--- a/LearningLens2025/frontend/pubspec.yaml
+++ b/LearningLens2025/frontend/pubspec.yaml
@@ -49,6 +49,9 @@ dependencies:
     sdk: flutter
   quill_delta: ^3.0.0-nullsafety.2
   vsc_quill_delta_to_html: ^1.0.5
+  super_clipboard: ^0.9.1
+  flutter_quill_delta_from_html: ^1.5.3
+  markdown: ^7.3.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Added the ability to copy form the chat interface while keeping format
-Added a copy to clipboard button to allow assistant messages to be copied since assistant messages render as lines that can only be copied one at a time.
-ctrl-v. right click paste, and toolbar button all work in quill. Paste outside of the app works. Will paste as rich-text or default to plain if rich isn't supported.

Small prompt changes

New dependencies for Delta -> HTML and clipboard.